### PR TITLE
Support iso8601 offsets

### DIFF
--- a/klock/src/commonMain/kotlin/com/soywiz/klock/Time.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/Time.kt
@@ -283,6 +283,8 @@ class OffsetDateTime private constructor(
 	override fun add(deltaMonths: Int, deltaMilliseconds: Long): DateTime =
 		OffsetDateTime(utc.add(deltaMonths, deltaMilliseconds), offset)
 
+	override fun toUtc(): DateTime = utc
+
 	override fun toString(): String = SimplerDateFormat.DEFAULT_FORMAT.format(this)
 }
 
@@ -527,7 +529,7 @@ inline val Number.seconds get() = TimeSpan.fromMilliseconds((this.toDouble() * 1
 
 class SimplerDateFormat(val format: String) {
 	companion object {
-		private val rx = Regex("('[\\w]+'|[\\w]+)")
+		private val rx = Regex("('[\\w]+'|[\\w]+\\B[^X]|[X]{1,3}|[\\w]+)")
 		private val englishDaysOfWeek = listOf(
 			"sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"
 		)
@@ -538,7 +540,7 @@ class SimplerDateFormat(val format: String) {
 		private val englishMonths3 = englishMonths.map { it.substr(0, 3) }
 
 		val DEFAULT_FORMAT by lazy { SimplerDateFormat("EEE, dd MMM yyyy HH:mm:ss z") }
-		val FORMAT1 by lazy { SimplerDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'") }
+		val FORMAT1 by lazy { SimplerDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX") }
 
 		val FORMATS = listOf(DEFAULT_FORMAT, FORMAT1)
 
@@ -564,8 +566,10 @@ class SimplerDateFormat(val format: String) {
 		parts += v
 		if (v.startsWith("'")) {
 			"(" + Regex.escapeReplacement(v.trim('\'')) + ")"
+		} else if (v.startsWith("X")) {
+			"([Z]|[+-]\\d\\d|[+-]\\d\\d\\d\\d|[+-]\\d\\d:\\d\\d)?"
 		} else {
-			"([\\w\\+\\-]+)"
+			"([\\w\\+\\-]+?[^Z^+^-])"
 		}
 	} + "$")
 
@@ -593,6 +597,17 @@ class SimplerDateFormat(val format: String) {
 				"HH" -> "%02d".format(dd.hours)
 				"mm" -> "%02d".format(dd.minutes)
 				"ss" -> "%02d".format(dd.seconds)
+				"X", "XX", "XXX" -> {
+					val p = if (dd.offset >= 0) "+" else "-"
+					val hours = dd.offset / 60
+					val minutes = dd.offset % 60
+					when (name) {
+						"X" -> "$p${"%02d".format(hours)}"
+						"XX" -> "$p${"%02d".format(hours)}${"%02d".format(minutes)}"
+						"XXX" -> "$p${"%02d".format(hours)}:${"%02d".format(minutes)}"
+						else -> name
+					}
+				}
 				else -> name
 			}
 		}
@@ -600,6 +615,7 @@ class SimplerDateFormat(val format: String) {
 	}
 
 	fun parse(str: String): Long = parseDate(str).unix
+	fun parseUtc(str: String): Long = parseDate(str).toUtc().unix
 
 	fun parseOrNull(str: String?): Long? = try {
 		str?.let { parse(str) }
@@ -618,6 +634,7 @@ class SimplerDateFormat(val format: String) {
 		var day = 1
 		var month = 1
 		var fullYear = 1970
+		var offset: Int? = null
 		val result = rx2.find(str) ?: return null
 		for ((name, value) in parts.zip(result.groupValues.drop(1))) {
 			when (name) {
@@ -630,13 +647,29 @@ class SimplerDateFormat(val format: String) {
 				"HH" -> hour = value.toInt()
 				"mm" -> minute = value.toInt()
 				"ss" -> second = value.toInt()
+				"X", "XX", "XXX" -> when {
+					value.first() == 'Z' -> offset = 0
+					else -> {
+						val hours = value.drop(1).substringBefore(':').toInt()
+						val minutes = value.substringAfter(':', "0").toInt()
+						offset = (hours * 60) + minutes
+						if (value.first() == '-') {
+							offset = -offset
+						}
+					}
+				}
 				else -> {
 					// ...
 				}
 			}
 		}
 		//return DateTime.createClamped(fullYear, month, day, hour, minute, second)
-		return DateTime.createAdjusted(fullYear, month, day, hour, minute, second)
+		val dateTime = DateTime.createAdjusted(fullYear, month, day, hour, minute, second)
+		return when (offset) {
+			null -> dateTime
+			0 -> dateTime.toUtc()
+			else -> dateTime.minus(TimeDistance(minutes = (offset).toDouble())).toOffset(offset)
+		}
 	}
 }
 

--- a/klock/src/commonTest/kotlin/com/soywiz/klock/SimplerDateFormatTest.kt
+++ b/klock/src/commonTest/kotlin/com/soywiz/klock/SimplerDateFormatTest.kt
@@ -21,4 +21,49 @@ class SimplerDateFormatTest {
 		val dateStr = "Sun, 06 Nov 1994 08:49:37 UTC"
 		assertEquals(dateStr, format.format(format.parse(dateStr)))
 	}
+
+	class ISO8601 {
+		val format = SimplerDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
+
+		@Test
+		fun testParseUtc() {
+			assertEquals(1462390174000, format.parse("2016-05-04T19:29:34+00:00"))
+		}
+
+		@Test
+		fun testFormatUtc() {
+			assertEquals("2016-05-04T19:29:34+00:00", format.format(1462390174000))
+		}
+
+		@Test
+		fun testParseFormatUtc() {
+			val dateStr = "2016-05-04T19:29:34+00:00"
+			assertEquals(dateStr, format.format(format.parse(dateStr)))
+		}
+
+		@Test
+		fun testParseWithOffsetAsUtc() {
+			val offsetDateStr = "2016-05-04T19:29:34+05:00"
+			val utcDateStr = "2016-05-04T14:29:34+00:00"
+			assertEquals(format.parse(utcDateStr), format.parseUtc(offsetDateStr))
+		}
+
+		@Test
+		fun testParseWithOffset() {
+			assertEquals(1462390174000, format.parse("2016-05-04T19:29:34-07:00"))
+		}
+
+		@Test
+		fun testParseFormatOffset() {
+			val dateStr = "2016-05-04T19:29:34+05:00"
+			assertEquals(dateStr, format.format(format.parseDate(dateStr)))
+		}
+
+		@Test
+		fun testParseWithZulu() {
+			val dateStr = "2016-05-04T19:29:34Z"
+			val expected = "2016-05-04T19:29:34+00:00"
+			assertEquals(format.parse(expected), format.parse(dateStr))
+		}
+	}
 }


### PR DESCRIPTION
Adds support for X, XX, and XXX offset formats.  This also adds a `parseUtc()` method to get the utc unix timestamp from an offset date string and changes the provided `FORMAT1` to `yyyy-MM-dd'T'HH:mm:ssXXX`.