### PR TITLE
Improved offset format support

### DIFF
--- a/klock/src/commonMain/kotlin/com/soywiz/klock/SimplerDateFormat.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/SimplerDateFormat.kt
@@ -3,7 +3,7 @@ package com.soywiz.klock
 
 class SimplerDateFormat(val format: String) {
 	companion object {
-		private val rx = Regex("('[\\w]+'|[\\w]+\\B[^X]|[X]{1,3}|[\\w]+)")
+		private val rx = Regex("('[\\w]+'|[\\w]+\\B[^Xx]|[Xx]{1,3}|[\\w]+)")
 		private val englishDaysOfWeek = listOf(
 			"sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"
 		)
@@ -40,7 +40,7 @@ class SimplerDateFormat(val format: String) {
 		parts += v
 		if (v.startsWith("'")) {
 			"(" + Regex.escapeReplacement(v.trim('\'')) + ")"
-		} else if (v.startsWith("X")) {
+		} else if (v.startsWith("X", ignoreCase = true)) {
 			"([Z]|[+-]\\d\\d|[+-]\\d\\d\\d\\d|[+-]\\d\\d:\\d\\d)?"
 		} else {
 			"([\\w\\+\\-]+?[^Z^+^-])"
@@ -81,15 +81,18 @@ class SimplerDateFormat(val format: String) {
 				"mm" -> dd.minutes.padded(2)
 				"s" -> dd.seconds.padded(1)
 				"ss" -> dd.seconds.padded(2)
-				"X", "XX", "XXX" -> {
-					val p = if (dd.offset >= 0) "+" else "-"
-					val hours = dd.offset / 60
-					val minutes = dd.offset % 60
-					when (name) {
-						"X" -> "$p${hours.padded(2)}"
-						"XX" -> "$p${hours.padded(2)}${minutes.padded(2)}"
-						"XXX" -> "$p${hours.padded(2)}:${minutes.padded(2)}"
-						else -> name
+				"X", "XX", "XXX", "x", "xx", "xxx" -> when {
+					name.startsWith("X") && dd.offset == 0 -> "Z"
+					else -> {
+						val p = if (dd.offset >= 0) "+" else "-"
+						val hours = dd.offset / 60
+						val minutes = dd.offset % 60
+						when (name) {
+							"X", "x" -> "$p${hours.padded(2)}"
+							"XX", "xx" -> "$p${hours.padded(2)}${minutes.padded(2)}"
+							"XXX", "xxx" -> "$p${hours.padded(2)}:${minutes.padded(2)}"
+							else -> name
+						}
 					}
 				}
 				"a" -> if (dd.hours<12) "am" else "pm"
@@ -134,9 +137,12 @@ class SimplerDateFormat(val format: String) {
 				"H", "HH" -> hour = value.toInt()
 				"m", "mm" -> minute = value.toInt()
 				"s", "ss" -> second = value.toInt()
-				"X", "XX", "XXX" -> when {
-					value.first() == 'Z' -> offset = 0
-					else -> {
+				"X", "XX", "XXX", "x", "xx", "xxx" -> when {
+					name.startsWith("X") && value.first() == 'Z' -> offset = 0
+					name.startsWith("x") && value.first() == 'Z' -> {
+						throw RuntimeException("Zulu Time Zone is only accepted with X-XXX formats.")
+					}
+					value.first() != 'Z' -> {
 						val hours = value.drop(1).substringBefore(':').toInt()
 						val minutes = value.substringAfter(':', "0").toInt()
 						offset = (hours * 60) + minutes

--- a/klock/src/commonTest/kotlin/com/soywiz/klock/SimplerDateFormatTest.kt
+++ b/klock/src/commonTest/kotlin/com/soywiz/klock/SimplerDateFormatTest.kt
@@ -22,8 +22,8 @@ class SimplerDateFormatTest {
 		assertEquals(dateStr, format.format(format.parse(dateStr)))
 	}
 
-	class ISO8601 {
-		val format = SimplerDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
+	class StrictOffset {
+		val format = SimplerDateFormat("yyyy-MM-dd'T'HH:mm:ssxxx")
 
 		@Test
 		fun testParseUtc() {
@@ -60,10 +60,43 @@ class SimplerDateFormatTest {
 		}
 
 		@Test
-		fun testParseWithZulu() {
+		fun testParseWithZuluFails() {
 			val dateStr = "2016-05-04T19:29:34Z"
-			val expected = "2016-05-04T19:29:34+00:00"
-			assertEquals(format.parse(expected), format.parse(dateStr))
+			assertFailsWith(RuntimeException::class, "Zulu Time Zone is only accepted with X-XXX formats.") {
+				format.parse(dateStr)
+			}
+		}
+	}
+
+	class ZuluCapableOffset {
+		val format = SimplerDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
+
+		@Test
+		fun testParseUtc() {
+			assertEquals(1462390174000, format.parse("2016-05-04T19:29:34+00:00"))
+		}
+
+		@Test
+		fun testParseZulu() {
+			assertEquals(1462390174000, format.parse("2016-05-04T19:29:34Z"))
+		}
+
+		@Test
+		fun testFormatUtc() {
+			assertEquals("2016-05-04T19:29:34Z", format.format(1462390174000))
+		}
+
+		@Test
+		fun testParseWithUtcOffsetFormatsWithZulu() {
+			val dateStr = "2016-05-04T19:29:34+00:00"
+			val expectedStr = "2016-05-04T19:29:34Z"
+			assertEquals(expectedStr, format.format(format.parse(dateStr)))
+		}
+
+		@Test
+		fun testParseWithZuluFormatsWithZulu() {
+			val dateStr = "2016-05-04T19:29:34Z"
+			assertEquals(dateStr, format.format(format.parse(dateStr)))
 		}
 	}
 }


### PR DESCRIPTION
This improves the X-XXX offset support such that the following case is now true
```kotlin
val format = SimplerDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX")
val dateStr = "2016-05-04T19:29:34Z"
assertEquals(dateStr, format.format(format.parse(dateStr)))
```
and adds support for x-xxx

Note: the 3 failing tests are unrelated to my changes.