### PR TITLE
Fix regex failure on native targets

### DIFF
--- a/klock/src/commonMain/kotlin/com/soywiz/klock/SimplerDateFormat.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/SimplerDateFormat.kt
@@ -43,7 +43,7 @@ class SimplerDateFormat(val format: String) {
 		} else if (v.startsWith("X", ignoreCase = true)) {
 			"([Z]|[+-]\\d\\d|[+-]\\d\\d\\d\\d|[+-]\\d\\d:\\d\\d)?"
 		} else {
-			"([\\w\\+\\-]+?[^Z^+^-])"
+			"([\\w\\+\\-]+[^Z^+^-])"
 		}
 	} + "$")
 


### PR DESCRIPTION
Any complete regex containing any characters after the first instance of `([\\w\\+\\-]+?[^Z^+^-])` will fail on native targets.  The explicit terminations make it unnecessary though improper formats may have issues.