### PR TITLE
Fix regex expression for single character flags

### DIFF
--- a/klock/src/commonMain/kotlin/com/soywiz/klock/SimplerDateFormat.kt
+++ b/klock/src/commonMain/kotlin/com/soywiz/klock/SimplerDateFormat.kt
@@ -43,7 +43,7 @@ class SimplerDateFormat(val format: String) {
 		} else if (v.startsWith("X", ignoreCase = true)) {
 			"([Z]|[+-]\\d\\d|[+-]\\d\\d\\d\\d|[+-]\\d\\d:\\d\\d)?"
 		} else {
-			"([\\w\\+\\-]+[^Z^+^-])"
+			"([\\w\\+\\-]*[^Z+-])"
 		}
 	} + "$")
 


### PR DESCRIPTION
This should fix the issue @luca992 found with single character flags.  If anyone has more cases that fail with this change, please send them my way.

It works for the following trivial test cases and all existing tests on jvm+native though I did not add them to this PR.
```
@Test
fun test() {
  val fmt = SimplerDateFormat("yyyy-MM-dd'T'h:mm:ssxxx")
  val dateUtc = "2016-05-04T9:29:34+00:00"
  fmt.parseDate(dateUtc)
}

@Test
fun test2() {
  val fmt = SimplerDateFormat("yyyy-M-dd'T'HH:mm:ssXXX")
  val dateZulu = "2016-5-04T19:29:34Z"
  fmt.parseDate(dateZulu)
}
```

When Klock makes its way back to its own repo, I will try and add sufficient tests for all flags and various formatters.  Again @soywiz, let me know if I can be of any help there, I've already fully configured and published a few libraries with the new MPP plugin.