### PR TITLE
`[korlibs-date]` Fix `S` pattern to be fraction of a second as specified in java's DateTimeFormatter

### DIFF
--- a/korlibs-time-core/src/korlibs/time/DateTime.kt
+++ b/korlibs-time-core/src/korlibs/time/DateTime.kt
@@ -253,8 +253,6 @@ value class DateTime(
     val seconds: Int get() = (yearOneMillis / MILLIS_PER_SECOND).toIntMod(60)
     /** The [milliseconds] part */
     val milliseconds: Int get() = (yearOneMillis).toIntMod(1000)
-    /** The [milliseconds] part */
-    val millisecondsDouble: Double get() = (yearOneMillis % 1000)
 
     /** Returns the quarter 1, 2, 3 or 4 */
     val quarter get() = (month0 / 3) + 1

--- a/korlibs-time-core/src/korlibs/time/DateTime.kt
+++ b/korlibs-time-core/src/korlibs/time/DateTime.kt
@@ -253,6 +253,8 @@ value class DateTime(
     val seconds: Int get() = (yearOneMillis / MILLIS_PER_SECOND).toIntMod(60)
     /** The [milliseconds] part */
     val milliseconds: Int get() = (yearOneMillis).toIntMod(1000)
+    /** The [milliseconds] part */
+    val millisecondsDouble: Double get() = (yearOneMillis % 1000)
 
     /** Returns the quarter 1, 2, 3 or 4 */
     val quarter get() = (month0 / 3) + 1

--- a/korlibs-time/src/korlibs/time/BasePatternDateTimeFormat.kt
+++ b/korlibs-time/src/korlibs/time/BasePatternDateTimeFormat.kt
@@ -35,7 +35,7 @@ abstract class BasePatternDateTimeFormat(
                         continue
                     }
                 }
-                chunks.add(s.tryReadOrNull("do") ?: s.tryReadOrNull("S*") ?: s.readRepeatedChar())
+                chunks.add(s.tryReadOrNull("do") ?: s.readRepeatedChar())
             }
         }.toList()
     }
@@ -102,7 +102,7 @@ abstract class BasePatternDateTimeFormat(
             "mm" -> """(\d{2})"""
             "s" -> """(\d{1,2})"""
             "ss" -> """(\d{2})"""
-            "S*", "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS" -> """(\d{1,9})"""
+            "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS" -> """(\d{1,9})"""
             "a" -> """(\w+)"""
             " " -> """(\s+)"""
             else -> null
@@ -154,8 +154,7 @@ abstract class BasePatternDateTimeFormat(
                 }
                 "m", "mm" -> minute = value.toInt()
                 "s", "ss" -> second = value.toInt()
-                "S*" -> millisecond = ("0.${value}".toDouble() * 1000).toInt()
-                "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS" -> millisecond = value.toInt()
+                "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS" -> millisecond = ("0.${value}".toDouble() * 1000).toInt()
                 "X", "XX", "XXX", "x", "xx", "xxx" -> {
                     when {
                         name.startsWith("X") && value.first() == 'Z' -> offset = 0.hours
@@ -262,9 +261,8 @@ abstract class BasePatternDateTimeFormat(
                 "m", "mm" -> minute.padded(nlen)
                 "s", "ss" -> second.padded(nlen)
 
-                "S*" -> (millisecond.toDouble() / 1000).toString().removePrefix("0.").trimStart('0').takeIf { it.isNotEmpty() } ?: "0"
                 "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS" -> {
-                    val res = millisecond.toString()
+                    val res = ((millisecond % 1000).toDouble() / 1000).toString().removePrefix("0.")
                     if (res.length < name.length) "000000000$millisecond".takeLast(name.length) else res
                 }
                 //"a" -> if (hour < 12) "am" else if (hour < 24) "pm" else ""

--- a/korlibs-time/src/korlibs/time/BasePatternDateTimeFormat.kt
+++ b/korlibs-time/src/korlibs/time/BasePatternDateTimeFormat.kt
@@ -116,12 +116,12 @@ abstract class BasePatternDateTimeFormat(
         var hour: Int = 0,
         var minute: Int = 0,
         var second: Int = 0,
-        var millisecond: Int = 0,
-        var offset: TimeSpan? = null,
+        var millisecond: Double = 0.0,
+        var offset: Duration? = null,
     )
 
     protected fun _tryParseBase(str: String, doThrow: Boolean, doAdjust: Boolean, realLocale: KlockLocale, tzNames: TimezoneNames): DateInfo? {
-        var millisecond = 0
+        var millisecond = 0.0
         var second = 0
         var minute = 0
         var hour = 0
@@ -154,7 +154,7 @@ abstract class BasePatternDateTimeFormat(
                 }
                 "m", "mm" -> minute = value.toInt()
                 "s", "ss" -> second = value.toInt()
-                "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS" -> millisecond = ("0.${value}".toDouble() * 1000).toInt()
+                "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS" -> millisecond = ("0.${value}".toDouble() * 1000)
                 "X", "XX", "XXX", "x", "xx", "xxx" -> {
                     when {
                         name.startsWith("X") && value.first() == 'Z' -> offset = 0.hours
@@ -249,7 +249,7 @@ abstract class BasePatternDateTimeFormat(
         }
 
         @JvmStatic
-        protected fun formatTimeChunk(name: String, realLocale: KlockLocale, hour: Int, minute: Int, second: Int, millisecond: Int, clampHours: Boolean): String? {
+        protected fun formatTimeChunk(name: String, realLocale: KlockLocale, hour: Int, minute: Int, second: Int, millisecond: Double, clampHours: Boolean): String? {
             val nlen = name.length
             return when (name) {
                 "H", "HH" -> (if (clampHours) mconvertRangeZero(hour, 24) else hour).padded(nlen)
@@ -262,8 +262,7 @@ abstract class BasePatternDateTimeFormat(
                 "s", "ss" -> second.padded(nlen)
 
                 "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS" -> {
-                    val res = ((millisecond % 1000).toDouble() / 1000).toString().removePrefix("0.")
-                    if (res.length < name.length) "000000000$millisecond".takeLast(name.length) else res
+                    ((millisecond % 1000) * 1_000_000).toInt().toString().padStart(9, '0').take(name.length)
                 }
                 //"a" -> if (hour < 12) "am" else if (hour < 24) "pm" else ""
                 "a" -> realLocale.h12Marker[if (hour < 12) 0 else 1]

--- a/korlibs-time/src/korlibs/time/BasePatternDateTimeFormat.kt
+++ b/korlibs-time/src/korlibs/time/BasePatternDateTimeFormat.kt
@@ -1,0 +1,309 @@
+package korlibs.time
+
+import korlibs.time.internal.*
+import kotlin.jvm.*
+import kotlin.math.*
+import kotlin.time.*
+
+abstract class BasePatternDateTimeFormat(
+    val baseFormat: String,
+    private val optionalSupport: Boolean,
+) {
+    private val openOffsets = LinkedHashMap<Int, Int>()
+    private val closeOffsets = LinkedHashMap<Int, Int>()
+
+    internal val chunks by lazy {
+        arrayListOf<String>().also { chunks ->
+            val s = MicroStrReader(baseFormat)
+            while (s.hasMore) {
+                if (s.peekChar() == '\'') {
+                    val escapedChunk = s.readChunk {
+                        s.tryRead('\'')
+                        while (s.hasMore && s.readChar() != '\'') Unit
+                    }
+                    chunks.add(escapedChunk)
+                    continue
+                }
+                if (optionalSupport) {
+                    val offset = chunks.size
+                    if (s.tryRead('[')) {
+                        openOffsets.increment(offset)
+                        continue
+                    }
+                    if (s.tryRead(']')) {
+                        closeOffsets.increment(offset - 1)
+                        continue
+                    }
+                }
+                chunks.add(s.tryReadOrNull("do") ?: s.tryReadOrNull("S*") ?: s.readRepeatedChar())
+            }
+        }.toList()
+    }
+
+    internal val regexChunks by lazy {
+        chunks.map {
+            matchChunkToRegex(it) ?: when {
+                it.startsWith('\'') -> "(" + Regex.escape(it.substr(1, it.length - 2)) + ")"
+                else -> "(" + Regex.escape(it) + ")"
+            }
+        }
+    }
+
+    //val escapedFormat = Regex.escape(format)
+    internal val rx2: Regex by lazy { Regex("^${matchingRegexString()}$") }
+
+
+    /**
+     * @return the regular expression string used for matching this format, able to be composed into another regex
+     */
+    fun matchingRegexString(): String = regexChunks.mapIndexed { index, it ->
+        if (optionalSupport) {
+            val opens = openOffsets.getOrElse(index) { 0 }
+            val closes = closeOffsets.getOrElse(index) { 0 }
+            buildString {
+                repeat(opens) { append("(?:") }
+                append(it)
+                repeat(closes) { append(")?") }
+            }
+        } else {
+            it
+        }
+    }.joinToString("")
+
+    protected abstract fun matchChunkToRegex(it: String): String?
+
+    protected fun matchDateChunkToRegex(it: String): String? {
+        return when (it) {
+            "E", "EE", "EEE", "EEEE", "EEEEE", "EEEEEE" -> """(\w+)"""
+            "z", "zzz" -> """([\w\s\-\+:]+)"""
+            "do" -> """(\d{1,2}\w+)"""
+            "d" -> """(\d{1,2})"""
+            "dd" -> """(\d{2})"""
+            "M" -> """(\d{1,5})"""
+            "MM" -> """(\d{2})"""
+            "MMM", "MMMM", "MMMMM" -> """(\w+)"""
+            "y" -> """(\d{1,5})"""
+            "yy" -> """(\d{2})"""
+            "yyy" -> """(\d{3})"""
+            "yyyy" -> """(\d{4})"""
+            "YYYY" -> """(\d{4})"""
+            "X", "XX", "XXX", "x", "xx", "xxx", "Z" -> """([\w:\+\-]+)"""
+            else -> null
+        }
+    }
+
+    protected fun matchTimeChunkToRegex(it: String): String? {
+        return when (it) {
+            "H", "k" -> """(\d{1,})"""
+            "HH", "kk" -> """(\d{2,})"""
+            "h", "K" -> """(\d{1,2})"""
+            "hh", "KK" -> """(\d{2})"""
+            "m" -> """(\d{1,2})"""
+            "mm" -> """(\d{2})"""
+            "s" -> """(\d{1,2})"""
+            "ss" -> """(\d{2})"""
+            "S" -> """(\d{1,9})""" // @TODO: This should be \d{1} to keep semantics
+            "S*" -> """(\d{1,9})"""
+            "SS" -> """(\d{2})"""
+            "SSS" -> """(\d{3})"""
+            "SSSS" -> """(\d{4})"""
+            "SSSSS" -> """(\d{5})"""
+            "SSSSSS" -> """(\d{6})"""
+            "SSSSSSS" -> """(\d{7})"""
+            "SSSSSSSS" -> """(\d{8})"""
+            "SSSSSSSSS" -> """(\d{9})"""
+            "a" -> """(\w+)"""
+            " " -> """(\s+)"""
+            else -> null
+        }
+    }
+
+    protected data class DateInfo(
+        var fullYear: Int = 1970,
+        var month: Int = 1,
+        var day: Int = 1,
+        var hour: Int = 0,
+        var minute: Int = 0,
+        var second: Int = 0,
+        var millisecond: Int = 0,
+        var offset: TimeSpan? = null,
+    )
+
+    protected fun _tryParseBase(str: String, doThrow: Boolean, doAdjust: Boolean, realLocale: KlockLocale, tzNames: TimezoneNames): DateInfo? {
+        var millisecond = 0
+        var second = 0
+        var minute = 0
+        var hour = 0
+        var day = 1
+        var month = 1
+        var fullYear = 1970
+        var offset: Duration? = null
+        var isPm = false
+        var is12HourFormat = false
+        val result = rx2.find(str) ?: return null //println("Parser error: Not match, $str, $rx2");
+        for ((name, value) in chunks.zip(result.groupValues.drop(1))) {
+            if (value.isEmpty()) continue
+
+            when (name) {
+                "E", "EE", "EEE", "EEEE", "EEEEE", "EEEEEE" -> Unit // day of week (Sun | Sunday)
+                "z", "zzz" -> { // timezone (GMT)
+                    offset = MicroStrReader(value).readTimeZoneOffset(tzNames)
+                }
+                "d", "dd" -> day = value.toInt()
+                "do" -> day = realLocale.getDayByOrdinal(value)
+                "M", "MM" -> month = value.toInt()
+                "MMM" -> month = realLocale.monthsShort.indexOf(value) + 1
+                "y", "yyyy", "YYYY" -> fullYear = value.toInt()
+                "yy" -> if (doThrow) throw RuntimeException("Not guessing years from two digits.") else return null
+                "yyy" -> fullYear = value.toInt() + if (value.toInt() < 800) 2000 else 1000 // guessing year...
+                "H", "HH", "k", "kk" -> hour = value.toInt()
+                "h", "hh", "K", "KK" -> {
+                    hour = value.toInt()
+                    is12HourFormat = true
+                }
+                "m", "mm" -> minute = value.toInt()
+                "s", "ss" -> second = value.toInt()
+                "S*" -> {
+                    millisecond = ("0.${value}".toDouble() * 1000).toInt()
+                }
+                "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS" -> {
+                    val base10length = log10(value.toDouble()).toInt() + 1
+                    millisecond = if (base10length > 3) {
+                        // only precision to millisecond supported, ignore the rest. ex: 9999999 => 999"
+                        (value.toDouble() * 10.0.pow(-1 * (base10length - 3))).toInt()
+                    } else {
+                        value.toInt()
+                    }
+                }
+                "X", "XX", "XXX", "x", "xx", "xxx" -> {
+                    when {
+                        name.startsWith("X") && value.first() == 'Z' -> offset = 0.hours
+                        name.startsWith("x") && value.first() == 'Z' -> {
+                            if (doThrow) throw RuntimeException("Zulu Time Zone is only accepted with X-XXX formats.") else return null
+                        }
+                        value.first() != 'Z' -> {
+                            val valueUnsigned = value.replace(":", "").removePrefix("-").removePrefix("+")
+                            val hours = when (name.length) {
+                                1 -> valueUnsigned.toInt()
+                                else -> valueUnsigned.take(2).toInt()
+                            }
+                            val minutes = when (name.length) {
+                                1 -> 0
+                                else -> valueUnsigned.drop(2).toInt()
+                            }
+                            offset = hours.hours + minutes.minutes
+                            if (value.first() == '-') {
+                                offset = -offset
+                            }
+                        }
+                    }
+                }
+                "MMMM" -> month = realLocale.months.indexOf(value) + 1
+                "MMMMM" -> if (doThrow) throw RuntimeException("Not possible to get the month from one letter.") else return null
+                "a" -> isPm = value.equals("pm", ignoreCase = true)
+                else -> {
+                    // ...
+                }
+            }
+        }
+        //return DateTime.createClamped(fullYear, month, day, hour, minute, second)
+        if (is12HourFormat) {
+            if (isPm) {
+                if (hour != 12) {
+                    hour += 12
+                }
+            } else {
+                if (hour == 12) {
+                    hour = 0
+                }
+            }
+        }
+
+        return DateInfo(fullYear, month, day, hour, minute, second, millisecond, offset)
+    }
+
+    companion object {
+        @JvmStatic
+        protected fun formatElseChunk(name: String): String {
+            return if (name.startsWith('\'')) name.substring(1, name.length - 1) else name
+        }
+
+        @JvmStatic
+        protected fun formatDateChunk(name: String, dd: DateTimeTz, realLocale: KlockLocale): String? {
+            val utc = dd.local
+            val nlen = name.length
+            return when (name) {
+                "E", "EE", "EEE" -> DayOfWeek[utc.dayOfWeek.index0].localShortName(realLocale)
+                "EEEE", "EEEEE", "EEEEEE" -> DayOfWeek[utc.dayOfWeek.index0].localName(realLocale)
+                "z", "zzz" -> dd.offset.timeZone
+                "d", "dd" -> utc.dayOfMonth.padded(nlen)
+                "do" -> realLocale.getOrdinalByDay(utc.dayOfMonth)
+                "M", "MM" -> utc.month1.padded(nlen)
+                "MMM" -> Month[utc.month1].localName(realLocale).substr(0, 3)
+                "MMMM" -> Month[utc.month1].localName(realLocale)
+                "MMMMM" -> Month[utc.month1].localName(realLocale).substr(0, 1)
+                "y" -> utc.yearInt.toString()
+                "yy" -> (utc.yearInt % 100).padded(2)
+                "yyy" -> (utc.yearInt % 1000).padded(3)
+                "yyyy" -> utc.yearInt.padded(4)
+                "YYYY" -> utc.yearInt.padded(4)
+
+                "X", "XX", "XXX", "x", "xx", "xxx" -> {
+                    when {
+                        name.startsWith("X") && dd.offset.totalMinutesInt == 0 -> "Z"
+                        else -> {
+                            val p = if (dd.offset.totalMinutesInt >= 0) "+" else "-"
+                            val hours = (dd.offset.totalMinutesInt / 60).absoluteValue
+                            val minutes = (dd.offset.totalMinutesInt % 60).absoluteValue
+                            when (name) {
+                                "X", "x" -> "$p${hours.padded(2)}"
+                                "XX", "xx" -> "$p${hours.padded(2)}${minutes.padded(2)}"
+                                "XXX", "xxx" -> "$p${hours.padded(2)}:${minutes.padded(2)}"
+                                else -> name
+                            }
+                        }
+                    }
+                }
+                else -> null
+            }
+        }
+
+        @JvmStatic
+        protected fun formatTimeChunk(name: String, realLocale: KlockLocale, hour: Int, minute: Int, second: Int, millisecond: Int, clampHours: Boolean): String? {
+            val nlen = name.length
+            return when (name) {
+                "H", "HH" -> (if (clampHours) mconvertRangeZero(hour, 24) else hour).padded(nlen)
+                "k", "kk" -> (if (clampHours) mconvertRangeNonZero(hour, 24) else hour).padded(nlen)
+
+                "h", "hh" -> mconvertRangeNonZero(hour, 12).padded(nlen)
+                "K", "KK" -> mconvertRangeZero(hour, 12).padded(nlen)
+
+                "m", "mm" -> minute.padded(nlen)
+                "s", "ss" -> second.padded(nlen)
+
+                "S*" -> (millisecond.toDouble() / 1000).toString().removePrefix("0.").trimStart('0').takeIf { it.isNotEmpty() } ?: "0"
+                "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS" -> {
+                    val milli = millisecond
+                    val numberLength = log10(millisecond.toDouble()).toInt() + 1
+                    if (numberLength > name.length) {
+                        (milli.toDouble() / 10.0.pow(numberLength - name.length)).toInt().toString()
+                    } else {
+                        "${milli.padded(3)}000000".substr(0, name.length)
+                    }
+                }
+                //"a" -> if (hour < 12) "am" else if (hour < 24) "pm" else ""
+                "a" -> realLocale.h12Marker[if (hour < 12) 0 else 1]
+                else -> null
+            }
+        }
+
+        private fun mconvertRangeZero(value: Int, size: Int): Int {
+            return (value umod size)
+        }
+
+        private fun mconvertRangeNonZero(value: Int, size: Int): Int {
+            val res = (value umod size)
+            return if (res == 0) size else res
+        }
+    }
+}

--- a/korlibs-time/src/korlibs/time/BasePatternDateTimeFormat.kt
+++ b/korlibs-time/src/korlibs/time/BasePatternDateTimeFormat.kt
@@ -249,7 +249,7 @@ abstract class BasePatternDateTimeFormat(
         }
 
         @JvmStatic
-        protected fun formatTimeChunk(name: String, realLocale: KlockLocale, hour: Int, minute: Int, second: Int, millisecond: Double, clampHours: Boolean): String? {
+        protected fun formatTimeChunk(name: String, realLocale: KlockLocale, hour: Int, minute: Int, second: Int, millisecond: Int, clampHours: Boolean): String? {
             val nlen = name.length
             return when (name) {
                 "H", "HH" -> (if (clampHours) mconvertRangeZero(hour, 24) else hour).padded(nlen)
@@ -262,7 +262,7 @@ abstract class BasePatternDateTimeFormat(
                 "s", "ss" -> second.padded(nlen)
 
                 "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS" -> {
-                    ((millisecond % 1000) * 1_000_000).toInt().toString().padStart(9, '0').take(name.length)
+                    ((millisecond % 1000) * 1_000_000).toString().padStart(9, '0').take(name.length)
                 }
                 //"a" -> if (hour < 12) "am" else if (hour < 24) "pm" else ""
                 "a" -> realLocale.h12Marker[if (hour < 12) 0 else 1]

--- a/korlibs-time/src/korlibs/time/BasePatternDateTimeFormat.kt
+++ b/korlibs-time/src/korlibs/time/BasePatternDateTimeFormat.kt
@@ -102,16 +102,7 @@ abstract class BasePatternDateTimeFormat(
             "mm" -> """(\d{2})"""
             "s" -> """(\d{1,2})"""
             "ss" -> """(\d{2})"""
-            "S" -> """(\d{1,9})""" // @TODO: This should be \d{1} to keep semantics
-            "S*" -> """(\d{1,9})"""
-            "SS" -> """(\d{2})"""
-            "SSS" -> """(\d{3})"""
-            "SSSS" -> """(\d{4})"""
-            "SSSSS" -> """(\d{5})"""
-            "SSSSSS" -> """(\d{6})"""
-            "SSSSSSS" -> """(\d{7})"""
-            "SSSSSSSS" -> """(\d{8})"""
-            "SSSSSSSSS" -> """(\d{9})"""
+            "S*", "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS" -> """(\d{1,9})"""
             "a" -> """(\w+)"""
             " " -> """(\s+)"""
             else -> null
@@ -163,18 +154,8 @@ abstract class BasePatternDateTimeFormat(
                 }
                 "m", "mm" -> minute = value.toInt()
                 "s", "ss" -> second = value.toInt()
-                "S*" -> {
-                    millisecond = ("0.${value}".toDouble() * 1000).toInt()
-                }
-                "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS" -> {
-                    val base10length = log10(value.toDouble()).toInt() + 1
-                    millisecond = if (base10length > 3) {
-                        // only precision to millisecond supported, ignore the rest. ex: 9999999 => 999"
-                        (value.toDouble() * 10.0.pow(-1 * (base10length - 3))).toInt()
-                    } else {
-                        value.toInt()
-                    }
-                }
+                "S*" -> millisecond = ("0.${value}".toDouble() * 1000).toInt()
+                "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS" -> millisecond = value.toInt()
                 "X", "XX", "XXX", "x", "xx", "xxx" -> {
                     when {
                         name.startsWith("X") && value.first() == 'Z' -> offset = 0.hours
@@ -283,13 +264,8 @@ abstract class BasePatternDateTimeFormat(
 
                 "S*" -> (millisecond.toDouble() / 1000).toString().removePrefix("0.").trimStart('0').takeIf { it.isNotEmpty() } ?: "0"
                 "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS" -> {
-                    val milli = millisecond
-                    val numberLength = log10(millisecond.toDouble()).toInt() + 1
-                    if (numberLength > name.length) {
-                        (milli.toDouble() / 10.0.pow(numberLength - name.length)).toInt().toString()
-                    } else {
-                        "${milli.padded(3)}000000".substr(0, name.length)
-                    }
+                    val res = millisecond.toString()
+                    if (res.length < name.length) "000000000$millisecond".takeLast(name.length) else res
                 }
                 //"a" -> if (hour < 12) "am" else if (hour < 24) "pm" else ""
                 "a" -> realLocale.h12Marker[if (hour < 12) 0 else 1]

--- a/korlibs-time/src/korlibs/time/BasePatternDateTimeFormat.kt
+++ b/korlibs-time/src/korlibs/time/BasePatternDateTimeFormat.kt
@@ -116,12 +116,14 @@ abstract class BasePatternDateTimeFormat(
         var hour: Int = 0,
         var minute: Int = 0,
         var second: Int = 0,
-        var millisecond: Double = 0.0,
+        var nanosecond: Int = 0,
         var offset: Duration? = null,
-    )
+    ) {
+        val millisecond get() = nanosecond / 1_000_000
+    }
 
     protected fun _tryParseBase(str: String, doThrow: Boolean, doAdjust: Boolean, realLocale: KlockLocale, tzNames: TimezoneNames): DateInfo? {
-        var millisecond = 0.0
+        var nanoseconds = 0
         var second = 0
         var minute = 0
         var hour = 0
@@ -154,7 +156,7 @@ abstract class BasePatternDateTimeFormat(
                 }
                 "m", "mm" -> minute = value.toInt()
                 "s", "ss" -> second = value.toInt()
-                "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS" -> millisecond = ("0.${value}".toDouble() * 1000)
+                "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS" -> nanoseconds = value.padEnd(9, '0').toInt()
                 "X", "XX", "XXX", "x", "xx", "xxx" -> {
                     when {
                         name.startsWith("X") && value.first() == 'Z' -> offset = 0.hours
@@ -199,7 +201,7 @@ abstract class BasePatternDateTimeFormat(
             }
         }
 
-        return DateInfo(fullYear, month, day, hour, minute, second, millisecond, offset)
+        return DateInfo(fullYear, month, day, hour, minute, second, nanoseconds, offset)
     }
 
     companion object {

--- a/korlibs-time/src/korlibs/time/DateFormat.kt
+++ b/korlibs-time/src/korlibs/time/DateFormat.kt
@@ -11,7 +11,9 @@ interface DateFormat {
         val FORMAT2 = DateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
         val FORMAT_DATE = DateFormat("yyyy-MM-dd")
 
-        val FORMATS = listOf(DEFAULT_FORMAT, FORMAT1, FORMAT2, FORMAT_DATE)
+        val ISO_DATE_TIME_OFFSET = DateFormat("yyyy-MM-dd'T'HH:mm[:ss[.S*]]Z").withOptional()
+
+        val FORMATS = listOf(DEFAULT_FORMAT, FORMAT1, FORMAT2, ISO_DATE_TIME_OFFSET, FORMAT_DATE)
 
         fun parse(date: String): DateTimeTz {
             var lastError: Throwable? = null

--- a/korlibs-time/src/korlibs/time/DateFormat.kt
+++ b/korlibs-time/src/korlibs/time/DateFormat.kt
@@ -11,7 +11,7 @@ interface DateFormat {
         val FORMAT2 = DateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
         val FORMAT_DATE = DateFormat("yyyy-MM-dd")
 
-        val ISO_DATE_TIME_OFFSET = DateFormat("yyyy-MM-dd'T'HH:mm[:ss[.S*]]Z").withOptional()
+        val ISO_DATE_TIME_OFFSET = DateFormat("yyyy-MM-dd'T'HH:mm[:ss[.S]]Z").withOptional()
 
         val FORMATS = listOf(DEFAULT_FORMAT, FORMAT1, FORMAT2, ISO_DATE_TIME_OFFSET, FORMAT_DATE)
 

--- a/korlibs-time/src/korlibs/time/ISO8601.kt
+++ b/korlibs-time/src/korlibs/time/ISO8601.kt
@@ -157,7 +157,7 @@ object ISO8601 {
                         seconds = if (nextComma || fmtReader.tryRead('.')) {
                             var count = 3
                             while (fmtReader.tryRead('s')) count++
-                            reader.tryReadDouble(count) ?: return reportParse("incorrect seconds")
+                            reader.tryReadDouble() ?: return reportParse("incorrect seconds")
                         } else {
                             reader.tryReadDouble(2) ?: return reportParse("incorrect seconds")
                         }

--- a/korlibs-time/src/korlibs/time/PatternDateFormat.kt
+++ b/korlibs-time/src/korlibs/time/PatternDateFormat.kt
@@ -56,21 +56,17 @@ data class PatternDateFormat(
     }
 
     override fun tryParse(str: String, doThrow: Boolean, doAdjust: Boolean): DateTimeTz? {
-        val (
-            fullYear, month, day,
-            hour, minute, second, millisecond,
-            offset,
-        ) = _tryParseBase(str, doThrow, doAdjust, realLocale, tzNames) ?: return null
+        val info = _tryParseBase(str, doThrow, doAdjust, realLocale, tzNames) ?: return null
         if (!doAdjust) {
-            if (month !in 1..12) if (doThrow) error("Invalid month $month") else return null
-            if (day !in 1..32) if (doThrow) error("Invalid day $day") else return null
-            if (hour !in 0..24) if (doThrow) error("Invalid hour $hour") else return null
-            if (minute !in 0..59) if (doThrow) error("Invalid minute $minute") else return null
-            if (second !in 0..59) if (doThrow) error("Invalid second $second") else return null
-            if (millisecond < 0.0 || millisecond >= 1000.0) if (doThrow) error("Invalid millisecond $millisecond") else return null
+            if (info.month !in 1..12) if (doThrow) error("Invalid month ${info.month}") else return null
+            if (info.day !in 1..32) if (doThrow) error("Invalid day ${info.day}") else return null
+            if (info.hour !in 0..24) if (doThrow) error("Invalid hour ${info.hour}") else return null
+            if (info.minute !in 0..59) if (doThrow) error("Invalid minute ${info.minute}") else return null
+            if (info.second !in 0..59) if (doThrow) error("Invalid second ${info.second}") else return null
+            if (info.millisecond !in 0 .. 999) if (doThrow) error("Invalid millisecond ${info.millisecond}") else return null
         }
-        val dateTime = DateTime.createAdjusted(fullYear, month, day, hour umod 24, minute, second, millisecond.toInt()) + (millisecond % 1).milliseconds
-        return dateTime.toOffsetUnadjusted(offset ?: 0.hours)
+        val dateTime = DateTime.createAdjusted(info.fullYear, info.month, info.day, info.hour umod 24, info.minute, info.second, info.millisecond)
+        return dateTime.toOffsetUnadjusted(info.offset ?: 0.hours)
     }
 
     override fun toString(): String = format

--- a/korlibs-time/src/korlibs/time/PatternDateFormat.kt
+++ b/korlibs-time/src/korlibs/time/PatternDateFormat.kt
@@ -50,7 +50,7 @@ data class PatternDateFormat(
         val locale = realLocale
         return chunks.joinToString("") {
             formatDateChunk(it, dd, locale)
-                ?: formatTimeChunk(it, locale, utc.hours, utc.minutes, utc.seconds, utc.millisecondsDouble, clampHours = true)
+                ?: formatTimeChunk(it, locale, utc.hours, utc.minutes, utc.seconds, utc.milliseconds, clampHours = true)
                 ?: formatElseChunk(it)
         }
     }

--- a/korlibs-time/src/korlibs/time/PatternDateFormat.kt
+++ b/korlibs-time/src/korlibs/time/PatternDateFormat.kt
@@ -50,7 +50,7 @@ data class PatternDateFormat(
         val locale = realLocale
         return chunks.joinToString("") {
             formatDateChunk(it, dd, locale)
-                ?: formatTimeChunk(it, locale, utc.hours, utc.minutes, utc.seconds, utc.milliseconds, clampHours = true)
+                ?: formatTimeChunk(it, locale, utc.hours, utc.minutes, utc.seconds, utc.millisecondsDouble, clampHours = true)
                 ?: formatElseChunk(it)
         }
     }
@@ -67,9 +67,9 @@ data class PatternDateFormat(
             if (hour !in 0..24) if (doThrow) error("Invalid hour $hour") else return null
             if (minute !in 0..59) if (doThrow) error("Invalid minute $minute") else return null
             if (second !in 0..59) if (doThrow) error("Invalid second $second") else return null
-            if (millisecond !in 0..999) if (doThrow) error("Invalid millisecond $millisecond") else return null
+            if (millisecond < 0.0 || millisecond >= 1000.0) if (doThrow) error("Invalid millisecond $millisecond") else return null
         }
-        val dateTime = DateTime.createAdjusted(fullYear, month, day, hour umod 24, minute, second, millisecond)
+        val dateTime = DateTime.createAdjusted(fullYear, month, day, hour umod 24, minute, second, millisecond.toInt()) + (millisecond % 1).milliseconds
         return dateTime.toOffsetUnadjusted(offset ?: 0.hours)
     }
 

--- a/korlibs-time/src/korlibs/time/PatternDateFormat.kt
+++ b/korlibs-time/src/korlibs/time/PatternDateFormat.kt
@@ -16,7 +16,7 @@ data class PatternDateFormat(
     val locale: KlockLocale? = null,
     val tzNames: TimezoneNames = TimezoneNames.DEFAULT,
     val options: Options = Options.DEFAULT
-) : DateFormat, Serializable {
+) : BasePatternDateTimeFormat(format, options.optionalSupport), DateFormat, Serializable {
     companion object {
         @Suppress("MayBeConstant", "unused")
         private const val serialVersionUID = 1L
@@ -40,252 +40,27 @@ data class PatternDateFormat(
     fun withOptional() = this.copy(options = options.copy(optionalSupport = true))
     fun withNonOptional() = this.copy(options = options.copy(optionalSupport = false))
 
-    private val openOffsets = LinkedHashMap<Int, Int>()
-    private val closeOffsets = LinkedHashMap<Int, Int>()
-
-    internal val chunks = arrayListOf<String>().also { chunks ->
-        val s = MicroStrReader(format)
-        while (s.hasMore) {
-            if (s.peekChar() == '\'') {
-                val escapedChunk = s.readChunk {
-                    s.tryRead('\'')
-                    while (s.hasMore && s.readChar() != '\'') Unit
-                }
-                chunks.add(escapedChunk)
-                continue
-            }
-            if (options.optionalSupport) {
-                val offset = chunks.size
-                if (s.tryRead('[')) {
-                    openOffsets.increment(offset)
-                    continue
-                }
-                if (s.tryRead(']')) {
-                    closeOffsets.increment(offset - 1)
-                    continue
-                }
-            }
-            chunks.add(s.tryReadOrNull("do") ?: s.readRepeatedChar())
-        }
-    }.toList()
-
-    internal val regexChunks: List<String> = chunks.map {
-        when (it) {
-            "E", "EE", "EEE", "EEEE", "EEEEE", "EEEEEE" -> """(\w+)"""
-            "z", "zzz" -> """([\w\s\-\+:]+)"""
-            "do" -> """(\d{1,2}\w+)"""
-            "d" -> """(\d{1,2})"""
-            "dd" -> """(\d{2})"""
-            "M" -> """(\d{1,5})"""
-            "MM" -> """(\d{2})"""
-            "MMM", "MMMM", "MMMMM" -> """(\w+)"""
-            "y" -> """(\d{1,5})"""
-            "yy" -> """(\d{2})"""
-            "yyy" -> """(\d{3})"""
-            "yyyy" -> """(\d{4})"""
-            "YYYY" -> """(\d{4})"""
-            "H", "k" -> """(\d{1,2})"""
-            "HH", "kk" -> """(\d{2})"""
-            "h", "K" -> """(\d{1,2})"""
-            "hh", "KK" -> """(\d{2})"""
-            "m" -> """(\d{1,2})"""
-            "mm" -> """(\d{2})"""
-            "s" -> """(\d{1,2})"""
-            "ss" -> """(\d{2})"""
-            "S" -> """(\d{1,9})"""
-            "SS" -> """(\d{2})"""
-            "SSS" -> """(\d{3})"""
-            "SSSS" -> """(\d{4})"""
-            "SSSSS" -> """(\d{5})"""
-            "SSSSSS" -> """(\d{6})"""
-            "SSSSSSS" -> """(\d{7})"""
-            "SSSSSSSS" -> """(\d{8})"""
-            "SSSSSSSSS" -> """(\d{9})"""
-            "X", "XX", "XXX", "x", "xx", "xxx", "Z" -> """([\w:\+\-]+)"""
-            "a" -> """(\w+)"""
-            " " -> """(\s+)"""
-            else -> when {
-                it.startsWith('\'') -> "(" + Regex.escape(it.substr(1, it.length - 2)) + ")"
-                else -> "(" + Regex.escape(it) + ")"
-            }
-        }
-    }
-
-    /**
-     * @return the regular expression string used for matching this format, able to be composed into another regex
-     */
-    fun matchingRegexString(): String = regexChunks.mapIndexed { index, it ->
-        if (options.optionalSupport) {
-            val opens = openOffsets.getOrElse(index) { 0 }
-            val closes = closeOffsets.getOrElse(index) { 0 }
-            buildString {
-                repeat(opens) { append("(?:") }
-                append(it)
-                repeat(closes) { append(")?") }
-            }
-        } else {
-            it
-        }
-    }.joinToString("")
-
-    //val escapedFormat = Regex.escape(format)
-    internal val rx2: Regex = Regex("^" + matchingRegexString() + "$")
-
+    override fun matchChunkToRegex(it: String): String? = matchDateChunkToRegex(it) ?: matchTimeChunkToRegex(it)
 
     // EEE, dd MMM yyyy HH:mm:ss z -- > Sun, 06 Nov 1994 08:49:37 GMT
     // YYYY-MM-dd HH:mm:ss
 
     override fun format(dd: DateTimeTz): String {
         val utc = dd.local
-        var out = ""
-        for (name in chunks) {
-            val nlen = name.length
-            out += when (name) {
-                "E", "EE", "EEE" -> DayOfWeek[utc.dayOfWeek.index0].localShortName(realLocale)
-                "EEEE", "EEEEE", "EEEEEE" -> DayOfWeek[utc.dayOfWeek.index0].localName(realLocale)
-                "z", "zzz" -> dd.offset.timeZone
-                "d", "dd" -> utc.dayOfMonth.padded(nlen)
-                "do" -> realLocale.getOrdinalByDay(utc.dayOfMonth)
-                "M", "MM" -> utc.month1.padded(nlen)
-                "MMM" -> Month[utc.month1].localName(realLocale).substr(0, 3)
-                "MMMM" -> Month[utc.month1].localName(realLocale)
-                "MMMMM" -> Month[utc.month1].localName(realLocale).substr(0, 1)
-                "y" -> utc.yearInt
-                "yy" -> (utc.yearInt % 100).padded(2)
-                "yyy" -> (utc.yearInt % 1000).padded(3)
-                "yyyy" -> utc.yearInt.padded(4)
-                "YYYY" -> utc.yearInt.padded(4)
-
-                "H", "HH" -> mconvertRangeZero(utc.hours, 24).padded(nlen)
-                "k", "kk" -> mconvertRangeNonZero(utc.hours, 24).padded(nlen)
-
-                "h", "hh" -> mconvertRangeNonZero(utc.hours, 12).padded(nlen)
-                "K", "KK" -> mconvertRangeZero(utc.hours, 12).padded(nlen)
-
-                "m", "mm" -> utc.minutes.padded(nlen)
-                "s", "ss" -> utc.seconds.padded(nlen)
-
-                "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS" -> {
-                    val milli = utc.milliseconds
-                    val base10length = log10(utc.milliseconds.toDouble()).toInt() + 1
-                    if (base10length > name.length) {
-                        (milli.toDouble() * 10.0.pow(-1 * (base10length - name.length))).toInt()
-                    } else {
-                        "${milli.padded(3)}000000".substr(0, name.length)
-                    }
-                }
-                "X", "XX", "XXX", "x", "xx", "xxx" -> {
-                    when {
-                        name.startsWith("X") && dd.offset.totalMinutesInt == 0 -> "Z"
-                        else -> {
-                            val p = if (dd.offset.totalMinutesInt >= 0) "+" else "-"
-                            val hours = (dd.offset.totalMinutesInt / 60).absoluteValue
-                            val minutes = (dd.offset.totalMinutesInt % 60).absoluteValue
-                            when (name) {
-                                "X", "x" -> "$p${hours.padded(2)}"
-                                "XX", "xx" -> "$p${hours.padded(2)}${minutes.padded(2)}"
-                                "XXX", "xxx" -> "$p${hours.padded(2)}:${minutes.padded(2)}"
-                                else -> name
-                            }
-                        }
-                    }
-                }
-                "a" -> realLocale.h12Marker[if (utc.hours < 12) 0 else 1]
-                else -> when {
-                    name.startsWith('\'') -> name.substring(1, name.length - 1)
-                    else -> name
-                }
-            }
+        val locale = realLocale
+        return chunks.joinToString("") {
+            formatDateChunk(it, dd, locale)
+                ?: formatTimeChunk(it, locale, utc.hours, utc.minutes, utc.seconds, utc.milliseconds, clampHours = true)
+                ?: formatElseChunk(it)
         }
-        return out
     }
 
     override fun tryParse(str: String, doThrow: Boolean, doAdjust: Boolean): DateTimeTz? {
-        var millisecond = 0
-        var second = 0
-        var minute = 0
-        var hour = 0
-        var day = 1
-        var month = 1
-        var fullYear = 1970
-        var offset: TimeSpan? = null
-        var isPm = false
-        var is12HourFormat = false
-        val result = rx2.find(str) ?: return null //println("Parser error: Not match, $str, $rx2");
-        for ((name, value) in chunks.zip(result.groupValues.drop(1))) {
-            if (value.isEmpty()) continue
-
-            when (name) {
-                "E", "EE", "EEE", "EEEE", "EEEEE", "EEEEEE" -> Unit // day of week (Sun | Sunday)
-                "z", "zzz" -> { // timezone (GMT)
-                    offset = MicroStrReader(value).readTimeZoneOffset(tzNames)
-                }
-                "d", "dd" -> day = value.toInt()
-                "do" -> day = realLocale.getDayByOrdinal(value)
-                "M", "MM" -> month = value.toInt()
-                "MMM" -> month = realLocale.monthsShort.indexOf(value) + 1
-                "y", "yyyy", "YYYY" -> fullYear = value.toInt()
-                "yy" -> if (doThrow) throw RuntimeException("Not guessing years from two digits.") else return null
-                "yyy" -> fullYear = value.toInt() + if (value.toInt() < 800) 2000 else 1000 // guessing year...
-                "H", "HH", "k", "kk" -> hour = value.toInt()
-                "h", "hh", "K", "KK" -> {
-                    hour = value.toInt()
-                    is12HourFormat = true
-                }
-                "m", "mm" -> minute = value.toInt()
-                "s", "ss" -> second = value.toInt()
-                "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS" -> {
-                    val base10length = log10(value.toDouble()).toInt() + 1
-                    millisecond = if (base10length > 3) {
-                        // only precision to millisecond supported, ignore the rest. ex: 9999999 => 999"
-                        (value.toDouble() * 10.0.pow(-1 * (base10length - 3))).toInt()
-                    } else {
-                        value.toInt()
-                    }
-                }
-                "X", "XX", "XXX", "x", "xx", "xxx" -> {
-                    when {
-                        name.startsWith("X") && value.first() == 'Z' -> offset = 0.hours
-                        name.startsWith("x") && value.first() == 'Z' -> {
-                            if (doThrow) throw RuntimeException("Zulu Time Zone is only accepted with X-XXX formats.") else return null
-                        }
-                        value.first() != 'Z' -> {
-                            val valueUnsigned = value.replace(":", "").removePrefix("-").removePrefix("+")
-                            val hours = when (name.length) {
-                                1 -> valueUnsigned.toInt()
-                                else -> valueUnsigned.take(2).toInt()
-                            }
-                            val minutes = when (name.length) {
-                                1 -> 0
-                                else -> valueUnsigned.drop(2).toInt()
-                            }
-                            offset = hours.hours + minutes.minutes
-                            if (value.first() == '-') {
-                                offset = -offset
-                            }
-                        }
-                    }
-                }
-                "MMMM" -> month = realLocale.months.indexOf(value) + 1
-                "MMMMM" -> if (doThrow) throw RuntimeException("Not possible to get the month from one letter.") else return null
-                "a" -> isPm = value.equals("pm", ignoreCase = true)
-                else -> {
-                    // ...
-                }
-            }
-        }
-        //return DateTime.createClamped(fullYear, month, day, hour, minute, second)
-        if (is12HourFormat) {
-            if (isPm) {
-                if (hour != 12) {
-                    hour += 12
-                }
-            } else {
-                if (hour == 12) {
-                    hour = 0
-                }
-            }
-        }
+        val (
+            fullYear, month, day,
+            hour, minute, second, millisecond,
+            offset,
+        ) = _tryParseBase(str, doThrow, doAdjust, realLocale, tzNames) ?: return null
         if (!doAdjust) {
             if (month !in 1..12) if (doThrow) error("Invalid month $month") else return null
             if (day !in 1..32) if (doThrow) error("Invalid day $day") else return null
@@ -299,20 +74,4 @@ data class PatternDateFormat(
     }
 
     override fun toString(): String = format
-}
-
-private fun mconvertRangeZero(value: Int, size: Int): Int {
-    return (value umod size)
-}
-
-private fun mconvertRangeNonZero(value: Int, size: Int): Int {
-    val res = (value umod size)
-    return if (res == 0) size else res
-}
-
-private fun MicroStrReader.readRepeatedChar(): String {
-    return readChunk {
-        val c = readChar()
-        while (hasMore && (tryRead(c))) Unit
-    }
 }

--- a/korlibs-time/src/korlibs/time/PatternTimeFormat.kt
+++ b/korlibs-time/src/korlibs/time/PatternTimeFormat.kt
@@ -40,7 +40,7 @@ data class PatternTimeFormat(
     override fun format(dd: Duration): String {
         val time = Time(dd)
         return chunks.joinToString("") {
-            formatTimeChunk(it, locale, time.hour, time.minute, time.second, time.millisecondDouble, clampHours = false)
+            formatTimeChunk(it, locale, time.hour, time.minute, time.second, time.millisecond, clampHours = false)
                 ?: formatElseChunk(it)
         }
     }

--- a/korlibs-time/src/korlibs/time/PatternTimeFormat.kt
+++ b/korlibs-time/src/korlibs/time/PatternTimeFormat.kt
@@ -8,6 +8,7 @@ import korlibs.time.internal.padded
 import korlibs.time.internal.substr
 import kotlin.math.log10
 import kotlin.math.pow
+import kotlin.time.*
 
 data class PatternTimeFormat(
     val format: String,
@@ -36,15 +37,15 @@ data class PatternTimeFormat(
 
     override fun matchChunkToRegex(it: String): String? = matchTimeChunkToRegex(it)
 
-    override fun format(dd: TimeSpan): String {
+    override fun format(dd: Duration): String {
         val time = Time(dd)
         return chunks.joinToString("") {
-            formatTimeChunk(it, locale, time.hour, time.minute, time.second, time.millisecond, clampHours = false)
+            formatTimeChunk(it, locale, time.hour, time.minute, time.second, time.millisecondDouble, clampHours = false)
                 ?: formatElseChunk(it)
         }
     }
 
-    override fun tryParse(str: String, doThrow: Boolean, doAdjust: Boolean): TimeSpan? {
+    override fun tryParse(str: String, doThrow: Boolean, doAdjust: Boolean): Duration? {
         val (_, _, _, hour, minute, second, millisecond, _) = _tryParseBase(str, doThrow, doAdjust, locale, TimezoneNames.DEFAULT) ?: return null
         return hour.hours + minute.minutes + second.seconds + millisecond.milliseconds
     }

--- a/korlibs-time/src/korlibs/time/PatternTimeFormat.kt
+++ b/korlibs-time/src/korlibs/time/PatternTimeFormat.kt
@@ -1,13 +1,6 @@
 package korlibs.time
 
 import korlibs.Serializable
-import korlibs.time.internal.*
-import korlibs.time.internal.MicroStrReader
-import korlibs.time.internal.increment
-import korlibs.time.internal.padded
-import korlibs.time.internal.substr
-import kotlin.math.log10
-import kotlin.math.pow
 import kotlin.time.*
 
 data class PatternTimeFormat(
@@ -46,8 +39,8 @@ data class PatternTimeFormat(
     }
 
     override fun tryParse(str: String, doThrow: Boolean, doAdjust: Boolean): Duration? {
-        val (_, _, _, hour, minute, second, millisecond, _) = _tryParseBase(str, doThrow, doAdjust, locale, TimezoneNames.DEFAULT) ?: return null
-        return hour.hours + minute.minutes + second.seconds + millisecond.milliseconds
+        val info = _tryParseBase(str, doThrow, doAdjust, locale, TimezoneNames.DEFAULT) ?: return null
+        return info.hour.hours + info.minute.minutes + info.second.seconds + info.millisecond.milliseconds
     }
 
     override fun toString(): String = format

--- a/korlibs-time/src/korlibs/time/PatternTimeFormat.kt
+++ b/korlibs-time/src/korlibs/time/PatternTimeFormat.kt
@@ -11,8 +11,9 @@ import kotlin.math.pow
 
 data class PatternTimeFormat(
     val format: String,
-    val options: Options = Options.DEFAULT
-) : TimeFormat, Serializable {
+    val options: Options = Options.DEFAULT,
+    val locale: KlockLocale = KlockLocale.default,
+) : BasePatternDateTimeFormat(format, options.optionalSupport), TimeFormat, Serializable {
     companion object {
         @Suppress("MayBeConstant", "unused")
         private const val serialVersionUID = 1L
@@ -28,155 +29,23 @@ data class PatternTimeFormat(
         }
     }
 
+    fun withLocale(locale: KlockLocale) = this.copy(locale = locale)
     fun withOptions(options: Options) = this.copy(options = options)
     fun withOptional() = this.copy(options = options.copy(optionalSupport = true))
     fun withNonOptional() = this.copy(options = options.copy(optionalSupport = false))
 
-    private val openOffsets = LinkedHashMap<Int, Int>()
-    private val closeOffsets = LinkedHashMap<Int, Int>()
-
-    internal val chunks = arrayListOf<String>().also { chunks ->
-        val s = MicroStrReader(format)
-        while (s.hasMore) {
-            if (s.peekChar() == '\'') {
-                val escapedChunk = s.readChunk {
-                    s.tryRead('\'')
-                    while (s.hasMore && s.readChar() != '\'') Unit
-                }
-                chunks.add(escapedChunk)
-                continue
-            }
-            if (options.optionalSupport) {
-                val offset = chunks.size
-                if (s.tryRead('[')) {
-                    openOffsets.increment(offset)
-                    continue
-                }
-                if (s.tryRead(']')) {
-                    closeOffsets.increment(offset - 1)
-                    continue
-                }
-            }
-            val chunk = s.readChunk {
-                val c = s.readChar()
-                while (s.hasMore && s.tryRead(c)) Unit
-            }
-            chunks.add(chunk)
-        }
-    }.toList()
-
-    private val regexChunks = chunks.map {
-        when (it) {
-            "H", "k" -> """(\d{1,})"""
-            "HH", "kk" -> """(\d{2,})"""
-            "h", "K" -> """(\d{1,2})"""
-            "hh", "KK" -> """(\d{2})"""
-            "m" -> """(\d{1,2})"""
-            "mm" -> """(\d{2})"""
-            "s" -> """(\d{1,2})"""
-            "ss" -> """(\d{2})"""
-            "S" -> """(\d{1,6})"""
-            "SS" -> """(\d{2})"""
-            "SSS" -> """(\d{3})"""
-            "SSSS" -> """(\d{4})"""
-            "SSSSS" -> """(\d{5})"""
-            "SSSSSS" -> """(\d{6})"""
-            "SSSSSSS" -> """(\d{7})"""
-            "SSSSSSSS" -> """(\d{8})"""
-            "a" -> """(\w+)"""
-            " " -> """(\s+)"""
-            else -> when {
-                it.startsWith('\'') -> "(" + Regex.escapeReplacement(it.substr(1, it.length - 2)) + ")"
-                else -> "(" + Regex.escapeReplacement(it) + ")"
-            }
-        }
-    }
-
-    private val rx2: Regex = Regex("^" + regexChunks.mapIndexed { index, it ->
-        if (options.optionalSupport) {
-            val opens = openOffsets.getOrElse(index) { 0 }
-            val closes = closeOffsets.getOrElse(index) { 0 }
-            buildString {
-                repeat(opens) { append("(?:") }
-                append(it)
-                repeat(closes) { append(")?") }
-            }
-        } else {
-            it
-        }
-    }.joinToString("") + "$")
-
-    private fun clampZero(value: Int, size: Int) = (value umod size)
-
-    private fun clampNonZero(value: Int, size: Int) = (value umod size).let { if (it == 0) size else it }
+    override fun matchChunkToRegex(it: String): String? = matchTimeChunkToRegex(it)
 
     override fun format(dd: TimeSpan): String {
         val time = Time(dd)
-        var out = ""
-        for (name in chunks) {
-            val nlen = name.length
-            out += when (name) {
-                "H", "HH" -> time.hour.padded(nlen)
-                "k", "kk" -> time.hour.padded(nlen)
-
-                "h", "hh" -> clampNonZero(time.hour, 12).padded(nlen)
-                "K", "KK" -> clampZero(time.hour, 12).padded(nlen)
-
-                "m", "mm" -> time.minute.padded(nlen)
-                "s", "ss" -> time.second.padded(nlen)
-
-                "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS" -> {
-                    val milli = time.millisecond
-                    val numberLength = log10(time.millisecond.toDouble()).toInt() + 1
-                    if (numberLength > name.length) {
-                        (milli.toDouble() / 10.0.pow(numberLength - name.length)).toInt()
-                    } else {
-                        "${milli.padded(3)}00000".substr(0, name.length)
-                    }
-                }
-                "a" -> if (time.hour < 12) "am" else if (time.hour < 24) "pm" else ""
-                else -> if (name.startsWith('\'')) name.substring(1, name.length - 1) else name
-            }
+        return chunks.joinToString("") {
+            formatTimeChunk(it, locale, time.hour, time.minute, time.second, time.millisecond, clampHours = false)
+                ?: formatElseChunk(it)
         }
-        return out
     }
 
     override fun tryParse(str: String, doThrow: Boolean, doAdjust: Boolean): TimeSpan? {
-        var millisecond = 0
-        var second = 0
-        var minute = 0
-        var hour = 0
-        var isPm = false
-        var is12HourFormat = false
-        val result = rx2.find(str) ?: return null //println("Parser error: Not match, $str, $rx2");
-        for ((name, value) in chunks.zip(result.groupValues.drop(1))) {
-            if (value.isEmpty()) continue
-            when (name) {
-                "H", "HH", "k", "kk" -> hour = value.toInt()
-                "h", "hh", "K", "KK" -> {
-                    hour = value.toInt() umod 24
-                    is12HourFormat = true
-                }
-                "m", "mm" -> minute = value.toInt()
-                "s", "ss" -> second = value.toInt()
-                "S", "SS", "SSS", "SSSS", "SSSSS", "SSSSSS" -> {
-                    val numberLength = log10(value.toDouble()).toInt() + 1
-                    millisecond = if (numberLength > 3) {
-                        // only precision to millisecond supported, ignore the rest: 9999999 => 999
-                        (value.toDouble() * 10.0.pow(-1 * (numberLength - 3))).toInt()
-                    } else {
-                        value.toInt()
-                    }
-                }
-                "a" -> isPm = value == "pm"
-                else -> {
-                    // ...
-                }
-            }
-        }
-        if (is12HourFormat && isPm) {
-            hour += 12
-        }
+        val (_, _, _, hour, minute, second, millisecond, _) = _tryParseBase(str, doThrow, doAdjust, locale, TimezoneNames.DEFAULT) ?: return null
         return hour.hours + minute.minutes + second.seconds + millisecond.milliseconds
     }
 

--- a/korlibs-time/src/korlibs/time/Time.kt
+++ b/korlibs-time/src/korlibs/time/Time.kt
@@ -3,12 +3,13 @@ package korlibs.time
 import korlibs.Serializable
 import kotlin.jvm.JvmInline
 import kotlin.math.abs
+import kotlin.time.*
 
 /**
  * Represents a union of [millisecond], [second], [minute] and [hour].
  */
 @JvmInline
-value class Time(val encoded: TimeSpan) : Comparable<Time>, Serializable {
+value class Time(val encoded: Duration) : Comparable<Time>, Serializable {
 	companion object {
         @Suppress("MayBeConstant", "unused")
         private const val serialVersionUID = 1L
@@ -24,6 +25,8 @@ value class Time(val encoded: TimeSpan) : Comparable<Time>, Serializable {
 	}
     /** The [millisecond] part. */
 	val millisecond: Int get() = abs((encoded.millisecondsInt / DIV_MILLISECONDS) % 1000)
+    /** The [millisecond] part. */
+    val millisecondDouble: Double get() = abs((encoded.milliseconds / DIV_MILLISECONDS) % 1000)
     /** The [second] part. */
     val second: Int get() = abs((encoded.millisecondsInt / DIV_SECONDS) % 60)
     /** The [minute] part. */

--- a/korlibs-time/src/korlibs/time/_Time.internal.kt
+++ b/korlibs-time/src/korlibs/time/_Time.internal.kt
@@ -152,7 +152,7 @@ internal class MicroStrReader(val str: String, var offset: Int = 0) {
         var decimals = false
         loop@while (hasMore) {
             when (val pc = peekChar()) {
-                ',' -> {
+                ',', '.' -> {
                     if (numCount == 0) {
                         return null
                     }
@@ -200,4 +200,9 @@ internal fun MicroStrReader.readTimeZoneOffset(tzNames: TimezoneNames = Timezone
     val minutes = part.substr(2, 2).padStart(2, '0').toIntOrNull() ?: return null
     val roffset = hours.hours + minutes.minutes
     return if (sign > 0) +roffset else -roffset
+}
+
+internal fun MicroStrReader.readRepeatedChar(): String = readChunk {
+    val c = readChar()
+    while (hasMore && (tryRead(c))) Unit
 }

--- a/korlibs-time/test/korlibs/time/DateFormatTest.kt
+++ b/korlibs-time/test/korlibs/time/DateFormatTest.kt
@@ -16,29 +16,28 @@ class DateFormatTest {
     fun testParseIsoFormat() {
         val iso8601JsonFormat = PatternDateFormat("yyyy-MM-ddTHH:mm:ss.SZ")
 
-        assertEquals("2020-01-01T13:12:30.001Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.1Z").toString(DateFormat.FORMAT2))
-        assertEquals("2020-01-01T13:12:30.001Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.01Z").toString(DateFormat.FORMAT2))
+        assertEquals("2020-01-01T13:12:30.100Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.1Z").toString(DateFormat.FORMAT2))
+        assertEquals("2020-01-01T13:12:30.010Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.01Z").toString(DateFormat.FORMAT2))
         assertEquals("2020-01-01T13:12:30.001Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.001Z").toString(DateFormat.FORMAT2))
-        assertEquals("2020-01-01T13:12:30.001Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.0001Z").toString(DateFormat.FORMAT2))
-        assertEquals("2020-01-01T13:12:30.001Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.00001Z").toString(DateFormat.FORMAT2))
-        assertEquals("2020-01-01T13:12:30.001Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.000001Z").toString(DateFormat.FORMAT2))
+        assertEquals("2020-01-01T13:12:30.000Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.0001Z").toString(DateFormat.FORMAT2))
+        assertEquals("2020-01-01T13:12:30.000Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.00001Z").toString(DateFormat.FORMAT2))
+        assertEquals("2020-01-01T13:12:30.000Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.000001Z").toString(DateFormat.FORMAT2))
 
         // Fails with "S" -> """(\d{1,6})""", now succeeds with (\d{1,9})
-        assertEquals("2020-01-01T13:12:30.001Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.0000001Z").toString(DateFormat.FORMAT2)) //7S
-        assertEquals("2020-01-01T13:12:30.001Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.00000001Z").toString(DateFormat.FORMAT2)) //8S
-        assertEquals("2020-01-01T13:12:30.001Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.000000001Z").toString(DateFormat.FORMAT2)) //9S
+        assertEquals("2020-01-01T13:12:30.000Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.0000001Z").toString(DateFormat.FORMAT2)) //7S
+        assertEquals("2020-01-01T13:12:30.000Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.00000001Z").toString(DateFormat.FORMAT2)) //8S
+        assertEquals("2020-01-01T13:12:30.000Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.000000001Z").toString(DateFormat.FORMAT2)) //9S
 
         //assertFailsWith<DateException> { iso8601JsonFormat.parse("2020-01-01T13:12:30.0000000001Z").toString(DateFormat.FORMAT2) } //10S
 
-        // Negative tests
-        assertNotEquals("2020-01-01T13:12:30.001Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.10Z").toString(DateFormat.FORMAT2))
-        assertNotEquals("2020-01-01T13:12:30.001Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.100Z").toString(DateFormat.FORMAT2))
-        assertNotEquals("2020-01-01T13:12:30.001Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.1000Z").toString(DateFormat.FORMAT2))
-        assertNotEquals("2020-01-01T13:12:30.001Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.10000Z").toString(DateFormat.FORMAT2))
-        assertNotEquals("2020-01-01T13:12:30.001Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.100000Z").toString(DateFormat.FORMAT2))
-        assertNotEquals("2020-01-01T13:12:30.001Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.1000000Z").toString(DateFormat.FORMAT2)) //7S
-        assertNotEquals("2020-01-01T13:12:30.001Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.10000000Z").toString(DateFormat.FORMAT2)) //8S
-        assertNotEquals("2020-01-01T13:12:30.001Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.100000000Z").toString(DateFormat.FORMAT2)) //9S
+        assertEquals("2020-01-01T13:12:30.100Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.10Z").toString(DateFormat.FORMAT2))
+        assertEquals("2020-01-01T13:12:30.100Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.100Z").toString(DateFormat.FORMAT2))
+        assertEquals("2020-01-01T13:12:30.100Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.1000Z").toString(DateFormat.FORMAT2))
+        assertEquals("2020-01-01T13:12:30.100Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.10000Z").toString(DateFormat.FORMAT2))
+        assertEquals("2020-01-01T13:12:30.100Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.100000Z").toString(DateFormat.FORMAT2))
+        assertEquals("2020-01-01T13:12:30.100Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.1000000Z").toString(DateFormat.FORMAT2)) //7S
+        assertEquals("2020-01-01T13:12:30.100Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.10000000Z").toString(DateFormat.FORMAT2)) //8S
+        assertEquals("2020-01-01T13:12:30.100Z", iso8601JsonFormat.parse("2020-01-01T13:12:30.100000000Z").toString(DateFormat.FORMAT2)) //9S
 
         //assertFailsWith<DateException> { iso8601JsonFormat.parse("2020-01-01T13:12:30.1000000000Z").toString(DateFormat.FORMAT2) } //10S
     }

--- a/korlibs-time/test/korlibs/time/DateFormatTest.kt
+++ b/korlibs-time/test/korlibs/time/DateFormatTest.kt
@@ -48,4 +48,31 @@ class DateFormatTest {
         val actual = DateFormat("z").parse("+09:00").offset
         assertEquals(expected, actual)
     }
+
+    @Test
+    fun testMillisKorlibsNew() {
+        assertEquals(1, DateFormat.ISO_DATE_TIME_OFFSET.parseUtc("2020-01-01T13:12:30.001Z").milliseconds)
+        assertEquals(10, DateFormat.ISO_DATE_TIME_OFFSET.parseUtc("2020-01-01T13:12:30.010Z").milliseconds)
+        assertEquals(100, DateFormat.ISO_DATE_TIME_OFFSET.parseUtc("2020-01-01T13:12:30.100Z").milliseconds)
+        assertEquals(100, DateFormat.ISO_DATE_TIME_OFFSET.parseUtc("2020-01-01T13:12:30.1Z").milliseconds)
+        assertEquals(100, DateFormat.ISO_DATE_TIME_OFFSET.parseUtc("2020-01-01T13:12:30.10Z").milliseconds)
+        assertEquals(100, DateFormat.ISO_DATE_TIME_OFFSET.parseUtc("2020-01-01T13:12:30.100Z").milliseconds)
+        assertEquals(100, DateFormat.ISO_DATE_TIME_OFFSET.parseUtc("2020-01-01T13:12:30.1000Z").milliseconds)
+
+        assertEquals(1, DateFormat("yyyy-MM-dd'T'HH:mm:ss.SZ").parseUtc("2020-01-01T13:12:30.001Z").milliseconds)
+        assertEquals(10, DateFormat("yyyy-MM-dd'T'HH:mm:ss.SZ").parseUtc("2020-01-01T13:12:30.010Z").milliseconds)
+        assertEquals(100, DateFormat("yyyy-MM-dd'T'HH:mm:ss.SZ").parseUtc("2020-01-01T13:12:30.100Z").milliseconds)
+        assertEquals(100, DateFormat("yyyy-MM-dd'T'HH:mm:ss.SZ").parseUtc("2020-01-01T13:12:30.1Z").milliseconds)
+        assertEquals(100, DateFormat("yyyy-MM-dd'T'HH:mm:ss.SZ").parseUtc("2020-01-01T13:12:30.10Z").milliseconds)
+        assertEquals(100, DateFormat("yyyy-MM-dd'T'HH:mm:ss.SZ").parseUtc("2020-01-01T13:12:30.100Z").milliseconds)
+        assertEquals(100, DateFormat("yyyy-MM-dd'T'HH:mm:ss.SZ").parseUtc("2020-01-01T13:12:30.1000Z").milliseconds)
+
+        assertEquals(1, DateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").parseUtc("2020-01-01T13:12:30.001Z").milliseconds)
+        assertEquals(10, DateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").parseUtc("2020-01-01T13:12:30.010Z").milliseconds)
+        assertEquals(100, DateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").parseUtc("2020-01-01T13:12:30.100Z").milliseconds)
+        assertEquals(100, DateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").parseUtc("2020-01-01T13:12:30.1Z").milliseconds)
+        assertEquals(100, DateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").parseUtc("2020-01-01T13:12:30.10Z").milliseconds)
+        assertEquals(100, DateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").parseUtc("2020-01-01T13:12:30.100Z").milliseconds)
+        assertEquals(100, DateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSZ").parseUtc("2020-01-01T13:12:30.1000Z").milliseconds)
+    }
 }

--- a/korlibs-time/test/korlibs/time/DateTimeTest.kt
+++ b/korlibs-time/test/korlibs/time/DateTimeTest.kt
@@ -58,8 +58,8 @@ class DateTimeTest {
     @Test
     fun testFormattingToCustomDateTimeFormatsWithMilliseconds009() {
         val dt = DateTime(2018, 9, 8, 4, 8, 9, 9)
-        assertEquals("Sat, 08 Sep 2018 04:08:9.9 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.S z"))
-        assertEquals("Sat, 08 Sep 2018 04:08:9.09 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SS z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.009 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.S z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.009 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SS z"))
         assertEquals("Sat, 08 Sep 2018 04:08:9.009 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSS z"))
         assertEquals("Sat, 08 Sep 2018 04:08:9.0009 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSS z"))
         assertEquals("Sat, 08 Sep 2018 04:08:9.00009 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSSS z"))
@@ -215,10 +215,10 @@ class DateTimeTest {
 
     @Test
     fun testParsingDateTimesWithDeciSeconds() {
-        var dtmilli = 1536379689009L
-        assertEquals(dtmilli, DateTime(2018, 9, 8, 4, 8, 9, 9).unixMillisLong)
+        var dtmilli = 1536379689900L
+        assertEquals(dtmilli, DateTime(2018, 9, 8, 4, 8, 9, 900).unixMillisLong)
         assertEquals(
-            message = "Sat, 08 Sep 2018 04:08:09.9 UTC",
+            message = "Sat, 08 Sep 2018 04:08:09.900 UTC",
             expected = dtmilli,
             actual = DateFormat("EEE, dd MMM yyyy HH:mm:ss.S z").parseLong("Sat, 08 Sep 2018 04:08:09.9 UTC")
         )
@@ -226,8 +226,8 @@ class DateTimeTest {
 
     @Test
     fun testParsingDateTimesWithCentiSeconds() {
-        var dtmilli = 1536379689099L
-        assertEquals(dtmilli, DateTime(2018, 9, 8, 4, 8, 9, 99).unixMillisLong)
+        var dtmilli = 1536379689990L
+        assertEquals(dtmilli, DateTime(2018, 9, 8, 4, 8, 9, 990).unixMillisLong)
         assertEquals(
             message = "Sat, 08 Sep 2018 04:08:09.99 UTC",
             expected = dtmilli,

--- a/korlibs-time/test/korlibs/time/DateTimeTest.kt
+++ b/korlibs-time/test/korlibs/time/DateTimeTest.kt
@@ -443,6 +443,12 @@ class DateTimeTest {
     }
 
     @Test
+    fun testBug123_2() {
+        val str2 = "1989-01-01T10:00:00.0Z"
+        assertEquals(str2, DateTime.parse(str2).format(DateFormat.ISO_DATE_TIME_OFFSET))
+    }
+
+    @Test
     fun testIssue131() {
         assertEquals(
             "2020-07-23T12:30:52.999000000Z",

--- a/korlibs-time/test/korlibs/time/DateTimeTest.kt
+++ b/korlibs-time/test/korlibs/time/DateTimeTest.kt
@@ -429,8 +429,8 @@ class DateTimeTest {
     @Test
     fun testIssue131() {
         assertEquals(
-            "2020-07-23T12:30:52.999125000Z",
-            DateTime(1595507452999.125).format("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZ")
+            "2020-07-23T12:30:52.999000000Z",
+            DateTime(1595507452999L).format("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZ")
         )
     }
 

--- a/korlibs-time/test/korlibs/time/DateTimeTest.kt
+++ b/korlibs-time/test/korlibs/time/DateTimeTest.kt
@@ -47,23 +47,23 @@ class DateTimeTest {
     @Test
     fun testFormattingToCustomDateTimeFormatsWithMilliseconds999() {
         val dt = DateTime(2018, 9, 8, 4, 8, 9, 999)
-        assertEquals("Sat, 08 Sep 2018 04:08:9.9 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.S z"))
-        assertEquals("Sat, 08 Sep 2018 04:08:9.99 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SS z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.999 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.S z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.999 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SS z"))
         assertEquals("Sat, 08 Sep 2018 04:08:9.999 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSS z"))
-        assertEquals("Sat, 08 Sep 2018 04:08:9.9990 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSS z"))
-        assertEquals("Sat, 08 Sep 2018 04:08:9.99900 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSSS z"))
-        assertEquals("Sat, 08 Sep 2018 04:08:9.999000 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSSSS z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.0999 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSS z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.00999 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSSS z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.000999 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSSSS z"))
     }
 
     @Test
     fun testFormattingToCustomDateTimeFormatsWithMilliseconds009() {
         val dt = DateTime(2018, 9, 8, 4, 8, 9, 9)
-        assertEquals("Sat, 08 Sep 2018 04:08:9.0 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.S z"))
-        assertEquals("Sat, 08 Sep 2018 04:08:9.00 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SS z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.9 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.S z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.09 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SS z"))
         assertEquals("Sat, 08 Sep 2018 04:08:9.009 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSS z"))
-        assertEquals("Sat, 08 Sep 2018 04:08:9.0090 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSS z"))
-        assertEquals("Sat, 08 Sep 2018 04:08:9.00900 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSSS z"))
-        assertEquals("Sat, 08 Sep 2018 04:08:9.009000 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSSSS z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.0009 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSS z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.00009 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSSS z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.000009 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSSSS z"))
     }
 
     @Test
@@ -245,28 +245,6 @@ class DateTimeTest {
             actual = DateFormat("EEE, dd MMM yyyy HH:mm:ss.SSS z").parseLong("Sat, 08 Sep 2018 04:08:09.999 UTC")
         )
     }
-
-    @Test
-    fun testParsingDateTimesWithGreaterPrecisionThanMillisecond() {
-        val dtmilli = 1536379689999L
-        assertEquals(dtmilli, DateTime(2018, 9, 8, 4, 8, 9, 999).unixMillisLong)
-        assertEquals(
-            message = "Sat, 08 Sep 2018 04:08:09.9999 UTC",
-            expected = dtmilli,
-            actual = DateFormat("EEE, dd MMM yyyy HH:mm:ss.SSSS z").parseLong("Sat, 08 Sep 2018 04:08:09.9999 UTC")
-        )
-        assertEquals(
-            message = "Sat, 08 Sep 2018 04:08:09.99999 UTC",
-            expected = dtmilli,
-            actual = DateFormat("EEE, dd MMM yyyy HH:mm:ss.SSSSS z").parseLong("Sat, 08 Sep 2018 04:08:09.99999 UTC")
-        )
-        assertEquals(
-            message = "Sat, 08 Sep 2018 04:08:09.999999 UTC",
-            expected = dtmilli,
-            actual = DateFormat("EEE, dd MMM yyyy HH:mm:ss.SSSSSS z").parseLong("Sat, 08 Sep 2018 04:08:09.999999 UTC")
-        )
-    }
-
 
     @Test
     fun testParse() {
@@ -451,7 +429,7 @@ class DateTimeTest {
     @Test
     fun testIssue131() {
         assertEquals(
-            "2020-07-23T12:30:52.999000000Z",
+            "2020-07-23T12:30:52.000000999Z",
             DateTime(1595507452999L).format("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZ")
         )
     }

--- a/korlibs-time/test/korlibs/time/DateTimeTest.kt
+++ b/korlibs-time/test/korlibs/time/DateTimeTest.kt
@@ -47,23 +47,23 @@ class DateTimeTest {
     @Test
     fun testFormattingToCustomDateTimeFormatsWithMilliseconds999() {
         val dt = DateTime(2018, 9, 8, 4, 8, 9, 999)
-        assertEquals("Sat, 08 Sep 2018 04:08:9.999 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.S z"))
-        assertEquals("Sat, 08 Sep 2018 04:08:9.999 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SS z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.9 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.S z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.99 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SS z"))
         assertEquals("Sat, 08 Sep 2018 04:08:9.999 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSS z"))
-        assertEquals("Sat, 08 Sep 2018 04:08:9.0999 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSS z"))
-        assertEquals("Sat, 08 Sep 2018 04:08:9.00999 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSSS z"))
-        assertEquals("Sat, 08 Sep 2018 04:08:9.000999 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSSSS z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.9990 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSS z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.99900 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSSS z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.999000 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSSSS z"))
     }
 
     @Test
     fun testFormattingToCustomDateTimeFormatsWithMilliseconds009() {
         val dt = DateTime(2018, 9, 8, 4, 8, 9, 9)
-        assertEquals("Sat, 08 Sep 2018 04:08:9.009 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.S z"))
-        assertEquals("Sat, 08 Sep 2018 04:08:9.009 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SS z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.0 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.S z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.00 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SS z"))
         assertEquals("Sat, 08 Sep 2018 04:08:9.009 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSS z"))
-        assertEquals("Sat, 08 Sep 2018 04:08:9.0009 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSS z"))
-        assertEquals("Sat, 08 Sep 2018 04:08:9.00009 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSSS z"))
-        assertEquals("Sat, 08 Sep 2018 04:08:9.000009 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSSSS z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.0090 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSS z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.00900 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSSS z"))
+        assertEquals("Sat, 08 Sep 2018 04:08:9.009000 UTC", dt.format("EEE, dd MMM yyyy HH:mm:s.SSSSSS z"))
     }
 
     @Test
@@ -429,8 +429,8 @@ class DateTimeTest {
     @Test
     fun testIssue131() {
         assertEquals(
-            "2020-07-23T12:30:52.000000999Z",
-            DateTime(1595507452999L).format("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZ")
+            "2020-07-23T12:30:52.999125000Z",
+            DateTime(1595507452999.125).format("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZ")
         )
     }
 

--- a/korlibs-time/test/korlibs/time/SimplerDateFormatTest.kt
+++ b/korlibs-time/test/korlibs/time/SimplerDateFormatTest.kt
@@ -30,7 +30,7 @@ class SimplerDateFormatTest {
 
     @Test
     fun testDateFormatMillisecondPrecisionIssue2197() {
-        _testDateFormatMillisecondPrecisionIssue2197(DateFormat("yyyy-MM-dd'T'HH:mm[:ss[.S*]]Z").withOptional())
+        _testDateFormatMillisecondPrecisionIssue2197(DateFormat("yyyy-MM-dd'T'HH:mm[:ss[.S]]Z").withOptional())
     }
 
     @Test

--- a/korlibs-time/test/korlibs/time/TimeFormatTest.kt
+++ b/korlibs-time/test/korlibs/time/TimeFormatTest.kt
@@ -16,8 +16,11 @@ class TimeFormatTest {
         assertEquals("00:23:12", TimeFormat("KK:mm:ss").format(time1))
 
         val time2 = Time(hour = 50, minute = 2, second = 0, millisecond = 109)
-        assertEquals("2:2:0.10", TimeFormat("h:m:s.SS").format(time2))
-        assertEquals("2:2:0.1", TimeFormat("h:m:s.S").format(time2))
+        assertEquals("2:2:0.00109", TimeFormat("h:m:s.SSSSS").format(time2))
+        assertEquals("2:2:0.0109", TimeFormat("h:m:s.SSSS").format(time2))
+        assertEquals("2:2:0.109", TimeFormat("h:m:s.SSS").format(time2))
+        assertEquals("2:2:0.109", TimeFormat("h:m:s.SS").format(time2))
+        assertEquals("2:2:0.109", TimeFormat("h:m:s.S").format(time2))
         assertEquals("2:2:0", TimeFormat("K:m:s").format(time2))
     }
 

--- a/korlibs-time/test/korlibs/time/TimeFormatTest.kt
+++ b/korlibs-time/test/korlibs/time/TimeFormatTest.kt
@@ -64,4 +64,19 @@ class TimeFormatTest {
 
         assertEquals(dateUnix.hours, dateUnixLocal.hours, "testFromUnix. now=$now, diff=$diff, dataUnix=$dateUnix, dateUnixLocal=$dateUnixLocal")
     }
+
+    // https://github.com/korlibs/korge/issues/2197
+    @Test
+    fun testTimeFormatMillisecondPrecisionIssue2197() {
+        val format = TimeFormat("HH:mm[:ss[.S*]]").withOptional()
+
+        assertEquals(0, format.parseTime("13:12").millisecond) //0
+        assertEquals(0, format.parseTime("13:12:01").millisecond) //0
+        assertEquals(100, format.parseTime("13:12:30.1").millisecond) // ❌ parsed as 1
+        assertEquals(1, format.parseTime("13:12:30.001").millisecond) //1
+        assertEquals(10, format.parseTime("13:12:30.010").millisecond) //10
+        assertEquals(100, format.parseTime("13:12:30.100").millisecond) //100
+        assertEquals(100, format.parseTime("13:12:30.10").millisecond) // ❌ parsed as 10
+        assertEquals(100, format.parseTime("13:12:30.100").millisecond) //100
+    }
 }

--- a/korlibs-time/test/korlibs/time/TimeFormatTest.kt
+++ b/korlibs-time/test/korlibs/time/TimeFormatTest.kt
@@ -71,7 +71,7 @@ class TimeFormatTest {
     // https://github.com/korlibs/korge/issues/2197
     @Test
     fun testTimeFormatMillisecondPrecisionIssue2197() {
-        val format = TimeFormat("HH:mm[:ss[.S*]]").withOptional()
+        val format = TimeFormat("HH:mm[:ss[.S]]").withOptional()
 
         assertEquals(0, format.parseTime("13:12").millisecond) //0
         assertEquals(0, format.parseTime("13:12:01").millisecond) //0

--- a/korlibs-time/test/korlibs/time/TimeFormatTest.kt
+++ b/korlibs-time/test/korlibs/time/TimeFormatTest.kt
@@ -16,11 +16,11 @@ class TimeFormatTest {
         assertEquals("00:23:12", TimeFormat("KK:mm:ss").format(time1))
 
         val time2 = Time(hour = 50, minute = 2, second = 0, millisecond = 109)
-        assertEquals("2:2:0.00109", TimeFormat("h:m:s.SSSSS").format(time2))
-        assertEquals("2:2:0.0109", TimeFormat("h:m:s.SSSS").format(time2))
+        assertEquals("2:2:0.10900", TimeFormat("h:m:s.SSSSS").format(time2))
+        assertEquals("2:2:0.1090", TimeFormat("h:m:s.SSSS").format(time2))
         assertEquals("2:2:0.109", TimeFormat("h:m:s.SSS").format(time2))
-        assertEquals("2:2:0.109", TimeFormat("h:m:s.SS").format(time2))
-        assertEquals("2:2:0.109", TimeFormat("h:m:s.S").format(time2))
+        assertEquals("2:2:0.10", TimeFormat("h:m:s.SS").format(time2))
+        assertEquals("2:2:0.1", TimeFormat("h:m:s.S").format(time2))
         assertEquals("2:2:0", TimeFormat("K:m:s").format(time2))
     }
 

--- a/korlibs-time/test@jvm/korlibs/time/JvmReferenceTest.kt
+++ b/korlibs-time/test@jvm/korlibs/time/JvmReferenceTest.kt
@@ -1,5 +1,6 @@
 package korlibs.time
 
+import java.text.*
 import java.time.*
 import java.time.format.*
 import java.util.*
@@ -46,6 +47,17 @@ class JvmReferenceTest {
         assertEquals(
             1540124184000L,
             klockParse("EEE, dd MMM yyyy HH:mm:ss X", "Sun, 21 Oct 2018 12:16:24 +0300")
+        )
+    }
+
+    @Test
+    fun testParsingDateTimesWithDeciSeconds() {
+        var dtmilli = 1536379689009L
+        assertEquals(dtmilli, DateTime(2018, 9, 8, 4, 8, 9, 9).unixMillisLong)
+        assertEquals(
+            message = "Sat, 08 Sep 2018 04:08:09.9 UTC",
+            expected = dtmilli,
+            actual = SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss.S z", Locale.ENGLISH).parse("Sat, 08 Sep 2018 04:08:09.9 UTC").time
         )
     }
 }


### PR DESCRIPTION
Retake on https://github.com/korlibs/korge/pull/2200
Fixes https://github.com/korlibs/korge/issues/2197

This changes the behaviour from [SimpleDateFormat](https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html) to [DateTimeFormatter](https://docs.oracle.com/javase%2F9%2Fdocs%2Fapi%2F%2F/java/time/format/DateTimeFormatter.html)