### PR TITLE
Add basic dependency info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # korlibs
 
-All the korlibs in a monorepo but KorGE itself.
+This repository hosts the libraries used by [KorGE (Kotlin Game Engine)](https://github.com/korlibs/korge).
+It contains all the modules but KorGE itself.
 
 For the old korlibs repo: <https://github.com/korlibs/korlibs-all>
+
+## Usage
+
+Modules are published to Maven Central under the `com.soywiz` group.
+
+For example, you can use `korlibs-crypto` as follows (replacing `X.X.X` with the latest release):
+
+```kotlin
+implementation("com.soywiz:korlibs-crypto:X.X.X")
+```


### PR DESCRIPTION
Adds basic info about how to pull in the dependencies.

## Background

We wanted to use the crypto module in a PoC of ours but thought this library wasn't published, so we initially copied the whole thing over. Later I found that the things are actually published, it's just not mentioned anywhere. This PR fixes that.. a bit.

I also wanted to add a complete list of all available modules, but it seems not everything is being published when I look at https://repo1.maven.org/maven2/com/soywiz/korge/ (for example: audio is missing, as well as xml/json serialization).

<details>
<summary>So the best I could put together is this, which is why I didn't include it in this PR.</summary>

## Available modules

| Module                       | Dependency                                    |
|------------------------------|-----------------------------------------------|
| `korlibs-concurrent`         | `com.soywiz.korge:korlibs-concurrent`         |
| `korlibs-crypto`             | `com.soywiz.korge:korlibs-crypto`             |
| `korlibs-datastructure`      | `com.soywiz.korge:korlibs-datastructure`      |
| `korlibs-inject`             | `com.soywiz.korge:korlibs-inject`             |
| `korlibs-logger`             | `com.soywiz.korge:korlibs-logger`             |
| `korlibs-math-core`          | `com.soywiz.korge:korlibs-math-core`          |
| `korlibs-memory`             | `com.soywiz.korge:korlibs-memory`             |
| `korlibs-platform`           | `com.soywiz.korge:korlibs-platform`           |
| `korlibs-serialization-csv`  | `com.soywiz.korge:korlibs-serialization-csv`  |
| `korlibs-serialization-toml` | `com.soywiz.korge:korlibs-serialization-toml` |
| `korlibs-serialization-yaml` | `com.soywiz.korge:korlibs-serialization-yaml` |
| `korlibs-template`           | `com.soywiz.korge:korlibs-template`           |
| `korlibs-time`               | `com.soywiz.korge:korlibs-time`               |
| `korlibs-util`               | `com.soywiz.korge:korlibs-util`               |
</details>

## Future idea

It would be nice to have a `README.md` file with some basic usage per module. I can write it for the crypto module, if desired, since we already had to figure this out ourselves.