### PR TITLE
`[korlibs-time]` Remove withOptional from DateTimeFormat and make optional support the default

### DIFF
--- a/korlibs-time/src/korlibs/time/BasePatternDateTimeFormat.kt
+++ b/korlibs-time/src/korlibs/time/BasePatternDateTimeFormat.kt
@@ -7,7 +7,6 @@ import kotlin.time.*
 
 abstract class BasePatternDateTimeFormat(
     val baseFormat: String,
-    private val optionalSupport: Boolean,
 ) {
     private val openOffsets = LinkedHashMap<Int, Int>()
     private val closeOffsets = LinkedHashMap<Int, Int>()
@@ -24,16 +23,14 @@ abstract class BasePatternDateTimeFormat(
                     chunks.add(escapedChunk)
                     continue
                 }
-                if (optionalSupport) {
-                    val offset = chunks.size
-                    if (s.tryRead('[')) {
-                        openOffsets.increment(offset)
-                        continue
-                    }
-                    if (s.tryRead(']')) {
-                        closeOffsets.increment(offset - 1)
-                        continue
-                    }
+                val offset = chunks.size
+                if (s.tryRead('[')) {
+                    openOffsets.increment(offset)
+                    continue
+                }
+                if (s.tryRead(']')) {
+                    closeOffsets.increment(offset - 1)
+                    continue
                 }
                 chunks.add(s.tryReadOrNull("do") ?: s.readRepeatedChar())
             }
@@ -57,16 +54,12 @@ abstract class BasePatternDateTimeFormat(
      * @return the regular expression string used for matching this format, able to be composed into another regex
      */
     fun matchingRegexString(): String = regexChunks.mapIndexed { index, it ->
-        if (optionalSupport) {
-            val opens = openOffsets.getOrElse(index) { 0 }
-            val closes = closeOffsets.getOrElse(index) { 0 }
-            buildString {
-                repeat(opens) { append("(?:") }
-                append(it)
-                repeat(closes) { append(")?") }
-            }
-        } else {
-            it
+        val opens = openOffsets.getOrElse(index) { 0 }
+        val closes = closeOffsets.getOrElse(index) { 0 }
+        buildString {
+            repeat(opens) { append("(?:") }
+            append(it)
+            repeat(closes) { append(")?") }
         }
     }.joinToString("")
 

--- a/korlibs-time/src/korlibs/time/DateFormat.kt
+++ b/korlibs-time/src/korlibs/time/DateFormat.kt
@@ -11,7 +11,7 @@ interface DateFormat {
         val FORMAT2 = DateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
         val FORMAT_DATE = DateFormat("yyyy-MM-dd")
 
-        val ISO_DATE_TIME_OFFSET = DateFormat("yyyy-MM-dd'T'HH:mm[:ss[.S]]Z").withOptional()
+        val ISO_DATE_TIME_OFFSET = DateFormat("yyyy-MM-dd'T'HH:mm[:ss[.S]]Z")
 
         val FORMATS = listOf(DEFAULT_FORMAT, FORMAT1, FORMAT2, ISO_DATE_TIME_OFFSET, FORMAT_DATE)
 

--- a/korlibs-time/src/korlibs/time/PatternDateFormat.kt
+++ b/korlibs-time/src/korlibs/time/PatternDateFormat.kt
@@ -15,8 +15,7 @@ data class PatternDateFormat(
     val format: String,
     val locale: KlockLocale? = null,
     val tzNames: TimezoneNames = TimezoneNames.DEFAULT,
-    val options: Options = Options.DEFAULT
-) : BasePatternDateTimeFormat(format, options.optionalSupport), DateFormat, Serializable {
+) : BasePatternDateTimeFormat(format), DateFormat, Serializable {
     companion object {
         @Suppress("MayBeConstant", "unused")
         private const val serialVersionUID = 1L
@@ -24,21 +23,8 @@ data class PatternDateFormat(
 
     val realLocale get() = locale ?: KlockLocale.default
 
-    data class Options(val optionalSupport: Boolean = false) : Serializable {
-        companion object {
-            @Suppress("MayBeConstant", "unused")
-            private const val serialVersionUID = 1L
-
-            val DEFAULT = Options(optionalSupport = false)
-            val WITH_OPTIONAL = Options(optionalSupport = true)
-        }
-    }
-
     fun withLocale(locale: KlockLocale?) = this.copy(locale = locale)
     fun withTimezoneNames(tzNames: TimezoneNames) = this.copy(tzNames = this.tzNames + tzNames)
-    fun withOptions(options: Options) = this.copy(options = options)
-    fun withOptional() = this.copy(options = options.copy(optionalSupport = true))
-    fun withNonOptional() = this.copy(options = options.copy(optionalSupport = false))
 
     override fun matchChunkToRegex(it: String): String? = matchDateChunkToRegex(it) ?: matchTimeChunkToRegex(it)
 

--- a/korlibs-time/src/korlibs/time/PatternTimeFormat.kt
+++ b/korlibs-time/src/korlibs/time/PatternTimeFormat.kt
@@ -5,28 +5,14 @@ import kotlin.time.*
 
 data class PatternTimeFormat(
     val format: String,
-    val options: Options = Options.DEFAULT,
     val locale: KlockLocale = KlockLocale.default,
-) : BasePatternDateTimeFormat(format, options.optionalSupport), TimeFormat, Serializable {
+) : BasePatternDateTimeFormat(format), TimeFormat, Serializable {
     companion object {
         @Suppress("MayBeConstant", "unused")
         private const val serialVersionUID = 1L
     }
 
-    data class Options(val optionalSupport: Boolean = false) : korlibs.Serializable {
-        companion object {
-            @Suppress("MayBeConstant", "unused")
-            private const val serialVersionUID = 1L
-
-            val DEFAULT = Options(optionalSupport = false)
-            val WITH_OPTIONAL = Options(optionalSupport = true)
-        }
-    }
-
     fun withLocale(locale: KlockLocale) = this.copy(locale = locale)
-    fun withOptions(options: Options) = this.copy(options = options)
-    fun withOptional() = this.copy(options = options.copy(optionalSupport = true))
-    fun withNonOptional() = this.copy(options = options.copy(optionalSupport = false))
 
     override fun matchChunkToRegex(it: String): String? = matchTimeChunkToRegex(it)
 

--- a/korlibs-time/test/korlibs/time/DateTimeRangeTest.kt
+++ b/korlibs-time/test/korlibs/time/DateTimeRangeTest.kt
@@ -50,7 +50,7 @@ class DateTimeRangeTest {
 
     @Test
     fun testOptionalPatterns() {
-        val format = PatternDateFormat("YYYY[-MM[-dd]]").withOptional()
+        val format = PatternDateFormat("YYYY[-MM[-dd]]")
         assertEquals("2019-01-01", format.parse("2019").toString(format))
         assertEquals("2019-09-01", format.parse("2019-09").toString(format))
         assertEquals("2019-09-03", format.parse("2019-09-03").toString(format))

--- a/korlibs-time/test/korlibs/time/KotlinNativeImmutabilityTest.kt
+++ b/korlibs-time/test/korlibs/time/KotlinNativeImmutabilityTest.kt
@@ -29,14 +29,14 @@ class KotlinNativeImmutabilityTest {
 
     companion object {
         private val myDateFormat1b = DateFormat("YYYY-MM-dd")
-        private val myDateFormat2b = DateFormat("YYYY[-MM[-dd]]").withOptional()
+        private val myDateFormat2b = DateFormat("YYYY[-MM[-dd]]")
         private val myDateTimeRange1b = DateTimeRange(DateTime(0L), DateTime(100L))
         private val myKlockLocale1b = KlockLocale.English()
     }
 }
 
 private val myDateFormat1a = DateFormat("YYYY-MM-dd")
-private val myDateFormat2a = DateFormat("YYYY[-MM[-dd]]").withOptional()
+private val myDateFormat2a = DateFormat("YYYY[-MM[-dd]]")
 
 private val myDateTimeRange1a = DateTimeRange(DateTime(0L), DateTime(100L))
 private val myKlockLocale1a = KlockLocale.English()

--- a/korlibs-time/test/korlibs/time/SimplerDateFormatTest.kt
+++ b/korlibs-time/test/korlibs/time/SimplerDateFormatTest.kt
@@ -30,7 +30,7 @@ class SimplerDateFormatTest {
 
     @Test
     fun testDateFormatMillisecondPrecisionIssue2197() {
-        _testDateFormatMillisecondPrecisionIssue2197(DateFormat("yyyy-MM-dd'T'HH:mm[:ss[.S]]Z").withOptional())
+        _testDateFormatMillisecondPrecisionIssue2197(DateFormat("yyyy-MM-dd'T'HH:mm[:ss[.S]]Z"))
     }
 
     @Test

--- a/korlibs-time/test/korlibs/time/TimeFormatTest.kt
+++ b/korlibs-time/test/korlibs/time/TimeFormatTest.kt
@@ -71,7 +71,7 @@ class TimeFormatTest {
     // https://github.com/korlibs/korge/issues/2197
     @Test
     fun testTimeFormatMillisecondPrecisionIssue2197() {
-        val format = TimeFormat("HH:mm[:ss[.S]]").withOptional()
+        val format = TimeFormat("HH:mm[:ss[.S]]")
 
         assertEquals(0, format.parseTime("13:12").millisecond) //0
         assertEquals(0, format.parseTime("13:12:01").millisecond) //0


### PR DESCRIPTION
Split of https://github.com/korlibs/korlibs/pull/61