### PR TITLE
`[korlibs-time]` Adds PatternDateTimeSpanFormat backed by PatternDateComponentsFormat, and allow to convert DateComponents back and forth between DateTimeSpan

### DIFF
--- a/korlibs-time/src/korlibs/time/DateComponents.kt
+++ b/korlibs-time/src/korlibs/time/DateComponents.kt
@@ -65,3 +65,18 @@ fun DateTimeTz.toDateComponents(): DateComponents = DateComponents(
     offset = this.offset.time,
     dayOfWeek = this.dayOfWeek,
 )
+
+fun DateComponents.toDateTimeSpan(): DateTimeSpan = DateTimeSpan(
+    years, months, 0, days, hours, minutes, seconds, (nanoseconds / 1_000_000).toDouble()
+)
+
+fun DateTimeSpan.toDateComponents(): DateComponents = DateComponents(
+    isDate = false,
+    years = this.years,
+    months = this.months,
+    days = this.daysIncludingWeeks,
+    hours = this.hours,
+    minutes = this.minutes,
+    seconds = this.seconds,
+    nanoseconds = this.nanoseconds,
+)

--- a/korlibs-time/src/korlibs/time/DateTimeSpan.kt
+++ b/korlibs-time/src/korlibs/time/DateTimeSpan.kt
@@ -102,6 +102,9 @@ data class DateTimeSpan(
     /** The [milliseconds] part as a double. */
     val milliseconds: Double get() = computed.milliseconds
 
+    /** The [nanoseconds] part as an int. */
+    val nanoseconds: Int get() = computed.nanoseconds
+
     /** The [secondsIncludingMilliseconds] part as a doble including seconds and milliseconds. */
     val secondsIncludingMilliseconds: Double get() = computed.secondsIncludingMilliseconds
 

--- a/korlibs-time/src/korlibs/time/DateTimeSpanFormat.kt
+++ b/korlibs-time/src/korlibs/time/DateTimeSpanFormat.kt
@@ -5,6 +5,10 @@ import kotlin.time.*
 interface DateTimeSpanFormat {
     fun format(dd: DateTimeSpan): String
     fun tryParse(str: String, doThrow: Boolean): DateTimeSpan?
+
+    companion object {
+        operator fun invoke(format: String, locale: KlockLocale? = null) = PatternDateTimeSpanFormat(format, locale)
+    }
 }
 
 fun DateTimeSpanFormat.format(dd: Duration): String = format(dd + 0.months)

--- a/korlibs-time/src/korlibs/time/PatternDateTimeSpanFormat.kt
+++ b/korlibs-time/src/korlibs/time/PatternDateTimeSpanFormat.kt
@@ -1,0 +1,25 @@
+package korlibs.time
+
+import korlibs.*
+
+data class PatternDateTimeSpanFormat(
+    val format: String,
+    val locale: KlockLocale? = null,
+) : DateTimeSpanFormat, Serializable {
+    companion object {
+        @Suppress("MayBeConstant", "unused")
+        private const val serialVersionUID = 1L
+    }
+
+    val realLocale: KlockLocale get() = locale ?: KlockLocale.default
+    fun withLocale(locale: KlockLocale?): PatternDateTimeSpanFormat = this.copy(locale = locale)
+
+    internal val privFormat by lazy { PatternDateComponentsFormat(format, locale) }
+
+    override fun format(dd: DateTimeSpan): String = privFormat.format(dd.toDateComponents())
+
+    override fun tryParse(str: String, doThrow: Boolean): DateTimeSpan? =
+        privFormat.tryParse(str, setDate = false, doThrow = doThrow)?.toDateTimeSpan()
+
+    override fun toString(): String = format
+}

--- a/korlibs-time/src/korlibs/time/PatternTimeFormat.kt
+++ b/korlibs-time/src/korlibs/time/PatternTimeFormat.kt
@@ -14,7 +14,7 @@ data class PatternTimeFormat(
 
     fun withLocale(locale: KlockLocale) = this.copy(locale = locale)
 
-    private val privFormat by lazy { PatternDateComponentsFormat(format, locale) }
+    internal val privFormat by lazy { PatternDateComponentsFormat(format, locale) }
 
     override fun format(dd: Duration): String = privFormat.format(dd.toDateComponents())
 

--- a/korlibs-time/test/korlibs/time/DateTimeSpanFormatTest.kt
+++ b/korlibs-time/test/korlibs/time/DateTimeSpanFormatTest.kt
@@ -1,0 +1,15 @@
+package korlibs.time
+
+import kotlin.test.*
+
+class DateTimeSpanFormatTest {
+    @Test
+    fun test() {
+        DateTimeSpanFormat("MM-dd-HH-mm-ss").also { format ->
+            val span = 3.months + 13.days + 99.hours + 73.minutes + 15.seconds
+            assertEquals(span, format.parse("03-13-99-73-15"))
+            assertEquals(span, format.parse("03-17-04-13-15"))
+            assertEquals("03-17-04-13-15", format.format(span))
+        }
+    }
+}


### PR DESCRIPTION
Split of https://github.com/korlibs/korlibs/pull/61