### PR TITLE
Documentation for CoreBitmap32, make QOI dependent on CoreBitmap32 rather than Bitmap32

### DIFF
--- a/korlibs-image-core/src/korlibs/image/core/CoreBitmap.kt
+++ b/korlibs-image-core/src/korlibs/image/core/CoreBitmap.kt
@@ -19,6 +19,10 @@ interface CoreBitmapIndexed : CoreBitmap {
 }
 
 interface CoreBitmap32 : CoreBitmap {
+    // This array should be of `width * height` size where the index of each pixel can be retrieved
+    // using `x + y * width`.
+    // Each pixel is represented by an integer in RGBA packed format where each component is 1 byte:
+    // (r) or (g shl 8) or (b shl 16) or (a shl 24)
     val ints: IntArray
 }
 

--- a/korlibs-image/src/korlibs/image/bitmap/Bitmap.kt
+++ b/korlibs-image/src/korlibs/image/bitmap/Bitmap.kt
@@ -283,6 +283,7 @@ abstract class Bitmap(
     }
 
     fun toBMP32IfRequired(): Bitmap32 = if (this is Bitmap32) this else this.toBMP32()
+    fun toCoreBMP32IfRequired(): CoreBitmap32 = if (this is CoreBitmap32) this else this.toBMP32()
 
     open fun contentEquals(other: Bitmap): Boolean {
         if (this.width != other.width) return false

--- a/korlibs-image/src/korlibs/image/format/QOI.kt
+++ b/korlibs-image/src/korlibs/image/format/QOI.kt
@@ -121,7 +121,7 @@ object QOI : ImageFormat("qoi") {
             index[QOI_COLOR_HASH(r, g, b, a) % 64] = lastCol
             outp[o++] = lastCol
         }
-        return ImageData(outBmp)
+        return ImageData(outBmp as Bitmap)
     }
 
     override fun writeImage(image: ImageData, s: SyncStream, props: ImageEncodingProps) {

--- a/korlibs-image/src/korlibs/image/format/QOI.kt
+++ b/korlibs-image/src/korlibs/image/format/QOI.kt
@@ -5,6 +5,7 @@ import korlibs.image.bitmap.Bitmap
 import korlibs.image.bitmap.Bitmap32
 import korlibs.image.color.RGBA
 import korlibs.image.color.RgbaArray
+import korlibs.image.core.CoreBitmap32
 import korlibs.io.lang.LATIN1
 import korlibs.io.stream.SyncStream
 import korlibs.io.stream.readAvailable
@@ -21,6 +22,8 @@ import korlibs.memory.*
 // for the bitmap that you'll be encoding.
 var ImageEncodingProps.preAllocatedArrayForQOI: UByteArrayInt? by extraProperty { null }
 
+// QOI spec:
+// https://qoiformat.org/qoi-specification.pdf
 object QOI : ImageFormat("qoi") {
     override fun decodeHeader(s: SyncStream, props: ImageDecodingProps): ImageInfo? {
         if (s.readStringz(4, LATIN1) != "qoif") return null
@@ -47,7 +50,7 @@ object QOI : ImageFormat("qoi") {
         val index = RgbaArray(64)
         val out = props.out
         val outBmp =
-            if (out != null && out.width == header.width && out.height == header.height && out is Bitmap32) {
+            if (out != null && out.width == header.width && out.height == header.height && out is CoreBitmap32) {
                 out.premultiplied = false
                 out
             } else {
@@ -125,7 +128,7 @@ object QOI : ImageFormat("qoi") {
         val bitmap = image.mainBitmap.toBMP32IfRequired()
         val pixels = RgbaArray(bitmap.ints)
         val index = RgbaArray(64)
-        val maxSize = calculateMaxSize(bitmap)
+        val maxSize = calculateMaxSize(image.mainBitmap)
         val bytes = if (props.preAllocatedArrayForQOI == null) {
             UByteArrayInt(maxSize)
         } else {


### PR DESCRIPTION
Making QOI dependent on CoreBitmap32 provides more flexibility for clients to be able to extend the interface to implement their own Bitmap implementations.