### PR TITLE
bugfix: Align dependencies of subprojects with repositories v6.1.x

### DIFF
--- a/korlibs-audio-core/build.gradle.kts
+++ b/korlibs-audio-core/build.gradle.kts
@@ -61,14 +61,10 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(projects.korlibsMathCore)
-            implementation(projects.korlibsConcurrent)
             api(projects.korlibsMathVector)
             implementation(projects.korlibsFfiLegacy)
             implementation(projects.korlibsPlatform)
             implementation(projects.korlibsIoFs)
-            implementation(projects.korlibsTime)
-            implementation(projects.korlibsDatastructure)
-            implementation(libs.jna.jna)
         }
 
         val appleIosTvosMain by creating {

--- a/korlibs-audio/build.gradle.kts
+++ b/korlibs-audio/build.gradle.kts
@@ -74,7 +74,6 @@ kotlin {
             api(projects.korlibsFfiLegacy)
             api(projects.korlibsLogger)
             api(projects.korlibsAnnotations)
-            implementation(projects.korlibsDatastructure)
         }
         commonTest.dependencies {
             implementation(projects.korlibsIo)

--- a/korlibs-bignumber/build.gradle.kts
+++ b/korlibs-bignumber/build.gradle.kts
@@ -59,10 +59,6 @@ kotlin {
     // TODO Add android native targets as well
 
     sourceSets {
-        commonMain.dependencies {
-            implementation(projects.korlibsPlatform)
-            implementation(libs.kotlinx.atomicfu)
-        }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
         }

--- a/korlibs-checksum/build.gradle.kts
+++ b/korlibs-checksum/build.gradle.kts
@@ -59,10 +59,6 @@ kotlin {
     // TODO Add android native targets as well
 
     sourceSets {
-        commonMain.dependencies {
-            implementation(projects.korlibsPlatform)
-            implementation(libs.kotlinx.atomicfu)
-        }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
         }

--- a/korlibs-crypto/build.gradle.kts
+++ b/korlibs-crypto/build.gradle.kts
@@ -75,8 +75,5 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.kotlin.test)
         }
-        webMain.dependencies {
-            implementation(libs.kotlinx.browser)
-        }
     }
 }

--- a/korlibs-datastructure-core/build.gradle.kts
+++ b/korlibs-datastructure-core/build.gradle.kts
@@ -62,7 +62,7 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(libs.kotlinx.atomicfu)
+            api(libs.kotlinx.atomicfu)
         }
 
         val nonJsMain by creating {

--- a/korlibs-encoding/build.gradle.kts
+++ b/korlibs-encoding/build.gradle.kts
@@ -59,10 +59,6 @@ kotlin {
     // TODO Add android native targets as well
 
     sourceSets {
-        commonMain.dependencies {
-            implementation(projects.korlibsPlatform)
-            implementation(libs.kotlinx.atomicfu)
-        }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
         }

--- a/korlibs-ffi-legacy/build.gradle.kts
+++ b/korlibs-ffi-legacy/build.gradle.kts
@@ -60,13 +60,18 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(projects.korlibsPlatform)
-            implementation(projects.korlibsDatastructure)
-            implementation(projects.korlibsMemory)
+            api(projects.korlibsIoFs)
+            api(projects.korlibsPlatform)
+            api(projects.korlibsDatastructure)
+            api(projects.korlibsMemory)
+            api(projects.korlibsAnnotations)
+            api(projects.korlibsConcurrent)
+            api(libs.kotlinx.coroutines.core)
         }
         jvmMain.dependencies {
-            implementation(libs.ksp.symbolProcessingApi)
-            implementation(libs.jna.jna)
+            api(libs.ksp.symbolProcessingApi)
+            api(libs.jna.jna)
+            api(libs.jna.platform)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/korlibs-ffi/build.gradle.kts
+++ b/korlibs-ffi/build.gradle.kts
@@ -73,7 +73,6 @@ kotlin {
             dependencies {
                 api(libs.jna.platform)
                 api(libs.jna.jna)
-
             }
         }
 

--- a/korlibs-image-core/build.gradle.kts
+++ b/korlibs-image-core/build.gradle.kts
@@ -70,9 +70,12 @@ kotlin {
             api(libs.jna.jna)
             api(libs.jna.platform)
         }
-        webMain.dependencies {
+        jsMain.dependencies {
             implementation(projects.korlibsWasm)
             implementation(projects.korlibsCompression)
+        }
+        wasmJsMain.dependencies {
+            implementation(libs.kotlinx.browser)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/korlibs-io-network-core/build.gradle.kts
+++ b/korlibs-io-network-core/build.gradle.kts
@@ -69,11 +69,10 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(projects.korlibsAnnotations)
-            api(projects.korlibsIoStream)
             implementation(projects.korlibsDatastructure)
+            implementation(projects.korlibsLogger)
             api(projects.korlibsPlatform)
             api(projects.korlibsIoStream)
-            implementation(projects.korlibsLogger)
             api(libs.kotlinx.coroutines.core)
         }
         commonTest.dependencies {

--- a/korlibs-io/build.gradle.kts
+++ b/korlibs-io/build.gradle.kts
@@ -86,7 +86,6 @@ kotlin {
             api(projects.korlibsSerialization)
             api(projects.korlibsIoFs)
             api(libs.kotlinx.atomicfu)
-            implementation(libs.jna.jna)
         }
 
         val concurrentMain by creating {

--- a/korlibs-math/build.gradle.kts
+++ b/korlibs-math/build.gradle.kts
@@ -67,7 +67,6 @@ kotlin {
             api(projects.korlibsNumber)
         }
         commonTest.dependencies {
-            implementation(projects.korlibsPlatform)
             implementation(libs.kotlin.test)
         }
     }

--- a/korlibs-string/build.gradle.kts
+++ b/korlibs-string/build.gradle.kts
@@ -60,8 +60,8 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(projects.korlibsPlatform)
-            implementation(libs.kotlinx.atomicfu)
+            api(projects.korlibsPlatform)
+            api(libs.kotlinx.atomicfu)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)


### PR DESCRIPTION
## Description

Comparing the current `korlibs-ffi-legacy` module with the [`module.yml`](https://github.com/korlibs/korlibs-ffi/blob/v6.1.1/korlibs-ffi-legacy/module.yaml) file of the `korlibs-ffi-legacy` module from the ffi repo, there are some differences that cause currently issues.

On the investigation, I noticed additional differences in the module configurations.

## Solution

This PR aligns the dependencies with the dependencies listed in all module repositories in the version 6.1.x.