### PR TITLE
chore: Disable kotlin warnings for current CI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.MavenPublishPlugin
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper
 
 group = "org.korge.korlibs"
 version = libs.versions.korlibs.get()
@@ -61,6 +63,17 @@ subprojects {
                     // connection.set("scm:git:git://github.com/username/mylibrary.git")
                     // developerConnection.set("scm:git:ssh://git@github.com/username/mylibrary.git")
                 }
+            }
+        }
+    }
+
+    // TODO Re-enable warnings once we address most of the reported ones
+    val isCi = System.getenv("CI") != null
+    plugins.withType<KotlinMultiplatformPluginWrapper> {
+        extensions.configure<KotlinMultiplatformExtension> {
+            compilerOptions {
+                allWarningsAsErrors.set(false)
+                suppressWarnings.set(isCi)
             }
         }
     }


### PR DESCRIPTION
## Description

As the current state of the project has many warnings that need to be addressed, showing all of them in the CI does not make sense and would spam the output with thousand of lines of warnings.

## Solution

This PR supresses the warnings for environments where `CI` is set to `true`. This is done via the kotlin compiler options for each module individually, as there is no project-wide `kotlin` plugin configuration.

## Additional Information

Once most of the warnings are addressed, this change should be reverted, so that we can follow strict code validation again.

The suppressions may not apply to modules that do not use the multiplatform plugin (which we may have one or two), but this is sufficient and most of the warnings are suppressed this way.