### PR TITLE
chore: Kotlin probable bugs

### DIFF
--- a/korlibs-bignumber/src/commonTest/kotlin/korlibs/bignumber/BigNumTest.kt
+++ b/korlibs-bignumber/src/commonTest/kotlin/korlibs/bignumber/BigNumTest.kt
@@ -189,7 +189,7 @@ class BigNumTest {
     @Test
     fun testNegativeBigNum() {
         val neg = "-1.5".bn
-        assertEquals(-1.bi, neg.toBigInt())
+        assertEquals((-1).bi, neg.toBigInt())
         assertTrue(neg.int.isNegative)
     }
 

--- a/korlibs-datastructure/src/commonMain/kotlin/korlibs/datastructure/_Datastructure_ds.kt
+++ b/korlibs-datastructure/src/commonMain/kotlin/korlibs/datastructure/_Datastructure_ds.kt
@@ -926,6 +926,7 @@ data class BVHVector(val data: DoubleArray) {
     override fun equals(other: Any?): Boolean = other is BVHVector && data.contentEquals(other.data)
 
     override fun toString(): String = "BVHVector(${data.joinToString(", ") { it.niceStr }})"
+    override fun hashCode(): Int = data.contentHashCode()
 }
 
 private fun checkDimensions(actual: Int, expected: Int) {

--- a/korlibs-datastructure/src/commonTest/kotlin/korlibs/datastructure/FastIdentityMapTest.kt
+++ b/korlibs-datastructure/src/commonTest/kotlin/korlibs/datastructure/FastIdentityMapTest.kt
@@ -8,7 +8,10 @@ class FastIdentityMapTest {
 	fun test() {
 		class Demo {
 			override fun hashCode(): Int = 0
-		}
+            override fun equals(other: Any?): Boolean {
+				return this === other
+            }
+        }
 
 		val map = FastIdentityMap<Demo, String>()
 		val i1 = Demo()

--- a/korlibs-dyn/src/commonTest/kotlin/korlibs/io/dynamic/DynCommonTest.kt
+++ b/korlibs-dyn/src/commonTest/kotlin/korlibs/io/dynamic/DynCommonTest.kt
@@ -73,8 +73,8 @@ class DynCommonTest {
 
 	@Test
 	fun testUnaryOps() {
-		assertEquals(-5, (-5.0.dyn).int)
-		assertEquals(5, (+5.0.dyn).int)
+		assertEquals(-5, (-(5.0.dyn)).int)
+		assertEquals(5, (+(5.0.dyn)).int)
 		assertEquals(-1, 0.dyn.inv().int)
 		assertEquals(false, true.dyn.not().bool)
 		assertEquals(true, false.dyn.not().bool)

--- a/korlibs-ffi-legacy/src/commonMain/kotlin/korlibs/ffi/FFILib.kt
+++ b/korlibs-ffi-legacy/src/commonMain/kotlin/korlibs/ffi/FFILib.kt
@@ -192,6 +192,16 @@ data class FFIPointerArray(val data: IntArray) : List<FFIPointer?> {
     }
     override fun containsAll(elements: Collection<FFIPointer?>): Boolean = vlist.containsAll(elements)
     override fun contains(element: FFIPointer?): Boolean = indexOf(element) >= 0
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as FFIPointerArray
+
+        return data.contentEquals(other.data)
+    }
+
+    override fun hashCode(): Int = data.contentHashCode()
 }
 
 fun FFIPointer.withOffset(offset: Int): FFIPointer? = FFIPointer(address + offset)

--- a/korlibs-io/src/commonMain/kotlin/korlibs/io/compression/zip/Zip.kt
+++ b/korlibs-io/src/commonMain/kotlin/korlibs/io/compression/zip/Zip.kt
@@ -210,7 +210,53 @@ data class ZipEntry(
     val internalAttributes: Int,
     val externalAttributes: Int,
     val commentBytes: ByteArray
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as ZipEntry
+
+        if (versionMadeBy != other.versionMadeBy) return false
+        if (extractVersion != other.extractVersion) return false
+        if (headerOffset != other.headerOffset) return false
+        if (compressionMethod != other.compressionMethod) return false
+        if (flags != other.flags) return false
+        if (date != other.date) return false
+        if (time != other.time) return false
+        if (crc32 != other.crc32) return false
+        if (compressedSize != other.compressedSize) return false
+        if (uncompressedSize != other.uncompressedSize) return false
+        if (diskNumberStart != other.diskNumberStart) return false
+        if (internalAttributes != other.internalAttributes) return false
+        if (externalAttributes != other.externalAttributes) return false
+        if (!nameBytes.contentEquals(other.nameBytes)) return false
+        if (!extraBytes.contentEquals(other.extraBytes)) return false
+        if (!commentBytes.contentEquals(other.commentBytes)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = versionMadeBy
+        result = 31 * result + extractVersion
+        result = 31 * result + headerOffset.hashCode()
+        result = 31 * result + compressionMethod
+        result = 31 * result + flags
+        result = 31 * result + date
+        result = 31 * result + time
+        result = 31 * result + crc32
+        result = 31 * result + compressedSize
+        result = 31 * result + uncompressedSize
+        result = 31 * result + diskNumberStart
+        result = 31 * result + internalAttributes
+        result = 31 * result + externalAttributes
+        result = 31 * result + nameBytes.contentHashCode()
+        result = 31 * result + extraBytes.contentHashCode()
+        result = 31 * result + commentBytes.contentHashCode()
+        return result
+    }
+}
 
 data class ZipEntry2(
     val path: String,

--- a/korlibs-io/src/commonMain/kotlin/korlibs/io/file/std/IsoVfs.kt
+++ b/korlibs-io/src/commonMain/kotlin/korlibs/io/file/std/IsoVfs.kt
@@ -391,7 +391,63 @@ object ISO {
 			predecessorVolumeDescriptorSequenceLocation = s.readS32LE(),
 			flags = s.readU16LE()
 		)
-	}
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || this::class != other::class) return false
+
+            other as UdfPrimaryVolumeDescriptor
+
+            if (volumeDescriptorSequenceNumber != other.volumeDescriptorSequenceNumber) return false
+            if (primaryVolumeDescriptorNumber != other.primaryVolumeDescriptorNumber) return false
+            if (volumeSequenceNumber != other.volumeSequenceNumber) return false
+            if (maximumVolumeSequenceNumber != other.maximumVolumeSequenceNumber) return false
+            if (interchangeLevel != other.interchangeLevel) return false
+            if (maximumInterchangeLevel != other.maximumInterchangeLevel) return false
+            if (characterSetList != other.characterSetList) return false
+            if (maximumCharacterSetList != other.maximumCharacterSetList) return false
+            if (predecessorVolumeDescriptorSequenceLocation != other.predecessorVolumeDescriptorSequenceLocation) return false
+            if (flags != other.flags) return false
+            if (descriptorTag != other.descriptorTag) return false
+            if (volumeId != other.volumeId) return false
+            if (volumeSetIdentifier != other.volumeSetIdentifier) return false
+            if (descriptorCharacterSet != other.descriptorCharacterSet) return false
+            if (explanatoryCharacterSet != other.explanatoryCharacterSet) return false
+            if (volumeAbstract != other.volumeAbstract) return false
+            if (volumeCopyrightNotice != other.volumeCopyrightNotice) return false
+            if (applicationIdentifier != other.applicationIdentifier) return false
+            if (recordingDateandTime != other.recordingDateandTime) return false
+            if (implementationIdentifier != other.implementationIdentifier) return false
+            if (!implementationUse.contentEquals(other.implementationUse)) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = volumeDescriptorSequenceNumber
+            result = 31 * result + primaryVolumeDescriptorNumber
+            result = 31 * result + volumeSequenceNumber
+            result = 31 * result + maximumVolumeSequenceNumber
+            result = 31 * result + interchangeLevel
+            result = 31 * result + maximumInterchangeLevel
+            result = 31 * result + characterSetList
+            result = 31 * result + maximumCharacterSetList
+            result = 31 * result + predecessorVolumeDescriptorSequenceLocation
+            result = 31 * result + flags
+            result = 31 * result + descriptorTag.hashCode()
+            result = 31 * result + volumeId.hashCode()
+            result = 31 * result + volumeSetIdentifier.hashCode()
+            result = 31 * result + descriptorCharacterSet.hashCode()
+            result = 31 * result + explanatoryCharacterSet.hashCode()
+            result = 31 * result + volumeAbstract.hashCode()
+            result = 31 * result + volumeCopyrightNotice.hashCode()
+            result = 31 * result + applicationIdentifier.hashCode()
+            result = 31 * result + recordingDateandTime.hashCode()
+            result = 31 * result + implementationIdentifier.hashCode()
+            result = 31 * result + implementationUse.contentHashCode()
+            return result
+        }
+    }
 
 	data class PrimaryVolumeDescriptor(
 		val volumeDescriptorHeader: VolumeDescriptorHeader,
@@ -462,7 +518,83 @@ object ISO {
 		) {
 			//println(this)
 		}
-	}
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || this::class != other::class) return false
+
+            other as PrimaryVolumeDescriptor
+
+            if (pad1 != other.pad1) return false
+            if (pad2 != other.pad2) return false
+            if (volumeSpaceSize != other.volumeSpaceSize) return false
+            if (volumeSetSize != other.volumeSetSize) return false
+            if (volumeSequenceNumber != other.volumeSequenceNumber) return false
+            if (logicalBlockSize != other.logicalBlockSize) return false
+            if (pathTableSize != other.pathTableSize) return false
+            if (typeLPathTable != other.typeLPathTable) return false
+            if (optType1PathTable != other.optType1PathTable) return false
+            if (typeMPathTable != other.typeMPathTable) return false
+            if (optTypeMPathTable != other.optTypeMPathTable) return false
+            if (fileStructureVersion != other.fileStructureVersion) return false
+            if (pad5 != other.pad5) return false
+            if (volumeDescriptorHeader != other.volumeDescriptorHeader) return false
+            if (systemId != other.systemId) return false
+            if (volumeId != other.volumeId) return false
+            if (!pad3.contentEquals(other.pad3)) return false
+            if (rootDirectoryRecord != other.rootDirectoryRecord) return false
+            if (volumeSetId != other.volumeSetId) return false
+            if (publisherId != other.publisherId) return false
+            if (preparerId != other.preparerId) return false
+            if (applicationId != other.applicationId) return false
+            if (copyrightFileId != other.copyrightFileId) return false
+            if (abstractFileId != other.abstractFileId) return false
+            if (bibliographicFileId != other.bibliographicFileId) return false
+            if (creationDate != other.creationDate) return false
+            if (modificationDate != other.modificationDate) return false
+            if (expirationDate != other.expirationDate) return false
+            if (effectiveDate != other.effectiveDate) return false
+            if (!applicationData.contentEquals(other.applicationData)) return false
+            if (!pad6.contentEquals(other.pad6)) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = pad1
+            result = 31 * result + pad2.hashCode()
+            result = 31 * result + volumeSpaceSize
+            result = 31 * result + volumeSetSize
+            result = 31 * result + volumeSequenceNumber
+            result = 31 * result + logicalBlockSize
+            result = 31 * result + pathTableSize
+            result = 31 * result + typeLPathTable
+            result = 31 * result + optType1PathTable
+            result = 31 * result + typeMPathTable
+            result = 31 * result + optTypeMPathTable
+            result = 31 * result + fileStructureVersion
+            result = 31 * result + pad5
+            result = 31 * result + volumeDescriptorHeader.hashCode()
+            result = 31 * result + systemId.hashCode()
+            result = 31 * result + volumeId.hashCode()
+            result = 31 * result + pad3.contentHashCode()
+            result = 31 * result + rootDirectoryRecord.hashCode()
+            result = 31 * result + volumeSetId.hashCode()
+            result = 31 * result + publisherId.hashCode()
+            result = 31 * result + preparerId.hashCode()
+            result = 31 * result + applicationId.hashCode()
+            result = 31 * result + copyrightFileId.hashCode()
+            result = 31 * result + abstractFileId.hashCode()
+            result = 31 * result + bibliographicFileId.hashCode()
+            result = 31 * result + creationDate.hashCode()
+            result = 31 * result + modificationDate.hashCode()
+            result = 31 * result + expirationDate.hashCode()
+            result = 31 * result + effectiveDate.hashCode()
+            result = 31 * result + applicationData.contentHashCode()
+            result = 31 * result + pad6.contentHashCode()
+            return result
+        }
+    }
 
 	data class VolumeDescriptorHeader(
 		val type: TypeEnum,

--- a/korlibs-math/src/commonMain/kotlin/korlibs/math/geom/_MathGeomMutable.kt
+++ b/korlibs-math/src/commonMain/kotlin/korlibs/math/geom/_MathGeomMutable.kt
@@ -2644,6 +2644,13 @@ data class MRectangle(
     @KormaMutableApi val int: MRectangleInt get() = MRectangleInt(x, y, width, height)
     val value: Rectangle get() = Rectangle(x, y, width, height)
 
+    override fun hashCode(): Int {
+        var result = x.hashCode()
+        result = 31 * result + y.hashCode()
+        result = 31 * result + width.hashCode()
+        result = 31 * result + height.hashCode()
+        return result
+    }
 }
 
 fun Rectangle.copyTo(out: MRectangle = MRectangle()): MRectangle = out.copyFrom(this)

--- a/korlibs-wasm/api/jvm/korlibs-wasm.api
+++ b/korlibs-wasm/api/jvm/korlibs-wasm.api
@@ -361,8 +361,13 @@ public final class korlibs/wasm/WasmExport {
 public final class korlibs/wasm/WasmExpr {
 	public fun <init> (Ljava/util/List;)V
 	public fun <init> ([Lkorlibs/wasm/WasmInstruction;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lkorlibs/wasm/WasmExpr;
+	public static synthetic fun copy$default (Lkorlibs/wasm/WasmExpr;Ljava/util/List;ILjava/lang/Object;)Lkorlibs/wasm/WasmExpr;
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getInstructions ()Ljava/util/List;
 	public final fun getInterpreterCode ()Lkorlibs/wasm/WasmInterpreterCode;
+	public fun hashCode ()I
 	public final fun setInterpreterCode (Lkorlibs/wasm/WasmInterpreterCode;)V
 	public fun toString ()Ljava/lang/String;
 }

--- a/korlibs-wasm/api/korlibs-wasm.klib.api
+++ b/korlibs-wasm/api/korlibs-wasm.klib.api
@@ -1191,6 +1191,10 @@ final class korlibs.wasm/WasmExpr { // korlibs.wasm/WasmExpr|null[0]
         final fun <get-interpreterCode>(): korlibs.wasm/WasmInterpreterCode? // korlibs.wasm/WasmExpr.interpreterCode.<get-interpreterCode>|<get-interpreterCode>(){}[0]
         final fun <set-interpreterCode>(korlibs.wasm/WasmInterpreterCode?) // korlibs.wasm/WasmExpr.interpreterCode.<set-interpreterCode>|<set-interpreterCode>(korlibs.wasm.WasmInterpreterCode?){}[0]
 
+    final fun component1(): kotlin.collections/List<korlibs.wasm/WasmInstruction> // korlibs.wasm/WasmExpr.component1|component1(){}[0]
+    final fun copy(kotlin.collections/List<korlibs.wasm/WasmInstruction> = ...): korlibs.wasm/WasmExpr // korlibs.wasm/WasmExpr.copy|copy(kotlin.collections.List<korlibs.wasm.WasmInstruction>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // korlibs.wasm/WasmExpr.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // korlibs.wasm/WasmExpr.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // korlibs.wasm/WasmExpr.toString|toString(){}[0]
 }
 

--- a/korlibs-wasm/src/commonMain/kotlin/korlibs/wasm/WasmCommon.kt
+++ b/korlibs-wasm/src/commonMain/kotlin/korlibs/wasm/WasmCommon.kt
@@ -536,13 +536,28 @@ data class WasmData(
     val data: ByteArray,
     val index: Int,
     val e: WasmExpr? = null,
-    //val ast: Wast.Expr? = null,
 ) {
-    //fun toAst(module: WasmModule): Wast.Stm = when {
-    //    e != null -> e.toAst(module, WasmFunc(-1, WasmReader.INT_FUNC_TYPE))
-    //    ast != null -> Wast.RETURN(ast)
-    //    else -> TODO()
-    //}
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as WasmData
+
+        if (memindex != other.memindex) return false
+        if (index != other.index) return false
+        if (!data.contentEquals(other.data)) return false
+        if (e != other.e) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = memindex
+        result = 31 * result + index
+        result = 31 * result + data.contentHashCode()
+        result = 31 * result + (e?.hashCode() ?: 0)
+        return result
+    }
 }
 
 class WasmCode constructor(val params: List<WastLocal>?, val locals: List<List<WastLocal>>, val body: WasmExpr) {

--- a/korlibs-wasm/src/commonMain/kotlin/korlibs/wasm/WasmReaderBinary.kt
+++ b/korlibs-wasm/src/commonMain/kotlin/korlibs/wasm/WasmReaderBinary.kt
@@ -468,7 +468,7 @@ class WasmReaderBinary {
     }
 }
 
-class WasmExpr(val instructions: List<WasmInstruction>) {
+data class WasmExpr(val instructions: List<WasmInstruction>) {
     constructor(vararg instructions: WasmInstruction) : this(instructions.toList())
     var interpreterCode: WasmInterpreterCode? = null
     override fun toString(): String = "WasmExpr[${instructions.size}]{${instructions.joinToString(",") { "${it.op}" }}}"

--- a/korlibs-wasm/src/commonMain/kotlin/korlibs/wasm/WasmRunInterpreter.kt
+++ b/korlibs-wasm/src/commonMain/kotlin/korlibs/wasm/WasmRunInterpreter.kt
@@ -1671,4 +1671,42 @@ data class WasmInterpreterCode constructor(
     val localsOffsets: IntArray = IntArray(0),
     val endStack: List<WasmType> = emptyList(),
     val debug: WasmDebugContext
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as WasmInterpreterCode
+
+        if (paramsSize != other.paramsSize) return false
+        if (localSize != other.localSize) return false
+        if (paramsCount != other.paramsCount) return false
+        if (localsCount != other.localsCount) return false
+        if (!instructions.contentEquals(other.instructions)) return false
+        if (!intPool.contentEquals(other.intPool)) return false
+        if (!longPool.contentEquals(other.longPool)) return false
+        if (!floatPool.contentEquals(other.floatPool)) return false
+        if (!doublePool.contentEquals(other.doublePool)) return false
+        if (!localsOffsets.contentEquals(other.localsOffsets)) return false
+        if (endStack != other.endStack) return false
+        if (debug != other.debug) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = paramsSize
+        result = 31 * result + localSize
+        result = 31 * result + paramsCount
+        result = 31 * result + localsCount
+        result = 31 * result + instructions.contentHashCode()
+        result = 31 * result + intPool.contentHashCode()
+        result = 31 * result + longPool.contentHashCode()
+        result = 31 * result + floatPool.contentHashCode()
+        result = 31 * result + doublePool.contentHashCode()
+        result = 31 * result + localsOffsets.contentHashCode()
+        result = 31 * result + endStack.hashCode()
+        result = 31 * result + debug.hashCode()
+        return result
+    }
+}


### PR DESCRIPTION
## Description

With the language upgrade new language features become available and we may optimize the code in various ways.

## Solution

This PR applies the two "kotlin probable bugs" inspection rules found:

- Ambiguous unary operator use with number constant
- MIssing hashCode and equals for data classes with array properties

## Additional Information

First fix (unary operator) is used for adding clarification where to apply the operator, so that the right function is called. The second fix should improve the overall stability of the project by making data classes comparable.