### PR TITLE
fix: A couple of text/border alignment issues

### DIFF
--- a/korlibs-image/src/commonMain/kotlin/korlibs/image/font/LazyBitmapFont.kt
+++ b/korlibs-image/src/commonMain/kotlin/korlibs/image/font/LazyBitmapFont.kt
@@ -105,14 +105,17 @@ class LazyBitmapFont(
                         fontSize, codePoint, slice,
                         //-border,
                         //(border - m.height - m.top + fm.ascent).toIntRound(), xadvance.toIntRound()
-                        -g.pos.x.toIntRound(),
+
+                        // The texture here is the slice, where sliceWithBounds() above trims the padding off every edge of the slice.
+                        // However, g.pos is in the untrimmed bitmap's coordinate space so we, must remove the padding again here, else
+                        // every glyph is placed the border width pixels away from where it should be.
+                        // The error is the same for every glyph so doesn't represent as misaligned, but the amount shifted varies
+                        // depending on atlas size
+                        -(g.pos.x - border).toIntRound(),
                         // The renderer draws the bottom of the glyph at (yoffset + texHeight).
-                        // As texHeight is derived using toIntCeil(), using toIntRound() here causes
-                        // a disagreement in the glyph's position.
-                        // This is most noticeable with flat-bottomed letters where
-                        // ceil(h) - round(h) can flip which side of 0 or 1 the .5 of its height
-                        // falls on
-                        -g.pos.y.toIntCeil(),
+                        // As texHeight is derived using toIntCeil(), using toIntRound() here causes a disagreement in the glyph's position.
+                        // This is most noticeable with flat-bottomed letters where ceil(h) - round(h) can flip which side of 0 or 1 the .5 of its height lands on
+                        -(g.pos.y - border).toIntCeil(),
                         xadvance.toIntRound(),
                     )
                 }

--- a/korlibs-image/src/commonMain/kotlin/korlibs/image/font/LazyBitmapFont.kt
+++ b/korlibs-image/src/commonMain/kotlin/korlibs/image/font/LazyBitmapFont.kt
@@ -106,7 +106,13 @@ class LazyBitmapFont(
                         //-border,
                         //(border - m.height - m.top + fm.ascent).toIntRound(), xadvance.toIntRound()
                         -g.pos.x.toIntRound(),
-                        -g.pos.y.toIntRound(),
+                        // The renderer draws the bottom of the glyph at (yoffset + texHeight).
+                        // As texHeight is derived using toIntCeil(), using toIntRound() here causes
+                        // a disagreement in the glyph's position.
+                        // This is most noticeable with flat-bottomed letters where
+                        // ceil(h) - round(h) can flip which side of 0 or 1 the .5 of its height
+                        // falls on
+                        -g.pos.y.toIntCeil(),
                         xadvance.toIntRound(),
                     )
                 }

--- a/korlibs-image/src/commonTest/kotlin/korlibs/image/font/LazyBitmapFontTest.kt
+++ b/korlibs-image/src/commonTest/kotlin/korlibs/image/font/LazyBitmapFontTest.kt
@@ -1,13 +1,63 @@
 package korlibs.image.font
 
-import kotlin.test.*
+import kotlin.math.absoluteValue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class LazyBitmapFontTest {
+
+    private val atlasSizes =
+        listOf(16.0, 24.0, 32.0, 40.0, 48.0, 64.0, 72.0, 96.0, 112.0, 128.0, 144.0, 192.0)
+
     @Test
     fun testEnsureSpaceIsEmpty() {
         val glyph = DefaultTtfFontAsBitmap.getOrNull(' '.code)
         val texture = glyph!!.texture
         assertEquals(0, texture.width)
         assertEquals(0, texture.height)
+    }
+
+    /**
+     * A renderer draws a glyph's bottom edge at `yoffset + texHeight`.
+     *
+     * The glyphs tested here report `top == 0` - their outline already sits on the baseline. For those,
+     * that sum is the gap between the baseline and their own ink (i.e. it should be zero). This should
+     * be the same value for all of them, at any atlas size.
+     *
+     * Which glyphs qualify is read from the metrics rather than hardcoded, so this makes no assumption
+     * about the default font's geometry.
+     *
+     * Several [atlasSizes] are scanned because the failure is size-dependent. A glyph's height can land
+     * above or below by a half pixel, so any single size can agree by luck. Sizes 32, 72, 112 and 144
+     * all happen to be lucky for this font and picking one of those would have made this test worthless.
+     */
+    @Test
+    fun `Glyphs that share a baseline with each other should agree on that baseline`() {
+        val distanceFields = listOf(null, "sdf")
+        atlasSizes.forEach { atlasSize ->
+            distanceFields.forEach { distanceField ->
+                val offsets = baselineOffsets(atlasSize, distanceField)
+
+                assertTrue(offsets.isNotEmpty(), "no flat-bottomed glyphs available to test")
+                assertEquals(
+                    expected = 1,
+                    actual = offsets.values.toSet().size,
+                    message = "glyphs sharing one baseline were placed on different rows " +
+                        "(atlasSize=$atlasSize, distanceField=$distanceField): $offsets",
+                )
+            }
+        }
+    }
+
+    /** Distance from the baseline to the drawn bottom edge, per flat-bottomed glyph. */
+    private fun baselineOffsets(atlasSize: Double, distanceField: String?): Map<Char, Int> {
+        val font = DefaultTtfFont.toLazyBitmapFont(atlasSize, distanceField)
+        return ('a'..'z')
+            .filter { DefaultTtfFont.getGlyphMetrics(atlasSize, it.code).top.absoluteValue < 1e-6 }
+            .associateWith { char ->
+                val glyph = font.getOrNull(char.code)!!
+                glyph.yoffset + glyph.texHeight
+            }
     }
 }

--- a/korlibs-image/src/commonTest/kotlin/korlibs/image/font/LazyBitmapFontTest.kt
+++ b/korlibs-image/src/commonTest/kotlin/korlibs/image/font/LazyBitmapFontTest.kt
@@ -50,6 +50,26 @@ class LazyBitmapFontTest {
         }
     }
 
+    /**
+     * Asserts that no borders/padding/etc shift fonts from their baseline.
+     */
+    @Test
+    fun `Glyphs should sit on their baseline regardless of atlasSize`() {
+        val distanceFields = listOf(null, "sdf")
+        atlasSizes.forEach { atlasSize ->
+            distanceFields.forEach { distanceField ->
+                val misplaced = baselineOffsets(atlasSize, distanceField).filterValues { it != 0 }
+
+                assertEquals(
+                    expected = emptyMap(),
+                    actual = misplaced,
+                    message = "glyphs were placed off their own baseline " +
+                        "(atlasSize=$atlasSize, distanceField=$distanceField)",
+                )
+            }
+        }
+    }
+
     /** Distance from the baseline to the drawn bottom edge, per flat-bottomed glyph. */
     private fun baselineOffsets(atlasSize: Double, distanceField: String?): Map<Char, Int> {
         val font = DefaultTtfFont.toLazyBitmapFont(atlasSize, distanceField)


### PR DESCRIPTION
# `LazyBitmapFont` places glyphs incorrectly (two independent defects)

| | |
|---|---|
| **Project** | `korlibs-image` (`org.korge.korlibs:korlibs-image`) |
| **Version** | `7.0.0-SNAPSHOT` @ `bed719d` (also present in latest 6.x)|
| **File** | [`korlibs-image/src/commonMain/kotlin/korlibs/image/font/LazyBitmapFont.kt`](../../korlibs-image/src/commonMain/kotlin/korlibs/image/font/LazyBitmapFont.kt) |
| **Affects** | all targets - the code is in `commonMain` |

## Summary

Text rendered though a `LazyBitmapFont` (used by all `VectorFont`s), is positioned wrongly in two separate ways:

- **Letters that share a baseline are drawn on different rows.** `yoffset` and `texHeight` reach
      a whole pixel by different rounding functions, and the residue lands in the glyph's position.
- **All text is offset by the atlas's padding.** The offsets are measured against the untrimmed
      glyph bitmap, but the slice stored alongside them has that padding trimmed off. Because the
      padding derives from the atlas size, **changing the atlas size silently moves the text**.

The two are unrelated and fixable independently. Defect 1 is the visible one; defect 2 is
invisible until you change atlas size, at which point it is very confusing.

> [!NOTE]
> **Pre-baked AngelCode `.fnt` fonts are unaffected.** Their offsets are authored integers read from the file (`BitmapFont.kt:289`, `:361`, `:419`) which is naturally self-consistent by construction, with no padding trim and no rounding pair to mismatch.

---

## Defect 1: `yoffset` and `texHeight` use different rounding styles

### Symptom

Flat-bottomed letters (`i` `l` `m` `n` `r` `h` `t` `f`) sit exactly on the baseline in the outlines,
so they must all render on the same row. They don't - some land a pixel lower. **Which** letters are
affected changes with the atlas size, which rules out the typeface as a cause.

### Root cause

A renderer places a glyph's bottom edge at `yoffset + texHeight`. Those two integers are produced by
different rounding functions applied to related quantities:

| | origin | rounding |
|---|---|---|
| `texHeight` | `Font.kt:144` - `gmetrics.height.toIntCeil() + border2`, padding later trimmed | **`ceil`** |
| `yoffset` | `LazyBitmapFont.kt:109` - `-g.pos.y.toIntRound()`, where `g.pos.y == height + top + border` | **`round`** |

For a flat-bottomed glyph `top == 0` exactly, so the sum collapses to:

```
ceil(height) - round(height)
```

This is **0** when the height's fractional part is above `.5` and **1** when below. Which side a
glyph falls on depends only on its own height, so glyphs sharing a baseline disagree by a whole atlas
pixel.

### Evidence

<details>
<summary><b>Per-glyph metrics - Inter Regular, 36px text / 144px SDF atlas, flat-bottomed letters</b></summary>

| char | `top` | `height` | `round(top+height)` | `ceil(height)` | mismatch |
|---|---:|---:|---:|---:|---:|
| `r` | 0.000000 | 79.734375 | 80 | 80 | 0 |
| `f` | 0.000000 | 109.687500 | 110 | 110 | 0 |
| `n` | 0.000000 | 79.593750 | 80 | 80 | 0 |
| `h` | 0.000000 | 104.765625 | 105 | 105 | 0 |
| `l` | 0.000000 | 104.765625 | 105 | 105 | 0 |
| `v` | 0.000000 | 78.609375 | 79 | 79 | 0 |
| **`i`** | 0.000000 | 108.210938 | 108 | **109** | **1** |
| **`m`** | 0.000000 | 80.015625 | 80 | **81** | **1** |
| **`t`** | −0.984375 | 98.296875 | 97 | **99** | **2** |

`t` is worth noting: Inter's `t` genuinely dips ~0.98px below the baseline, so 1 of its 2 is real
geometry and only the other is the bug.

</details>

Measured on the framebuffer, the flat-letter set spanned **2 distinct pixel rows** before the fix and
**1** after.

> [!NOTE]
> **Oversampling does not help.** I tried oversampling, but the split presents identically at 1x, 2x, 4x and 8x atlas sizes. The error is baked into the atlas entry at build time so is unaffected by later global transforms.

#### It is size-dependent, and some atlas sizes are correct by luck

Because the mismatch is `ceil(h) − round(h)`, whether the font jitters depends on where each glyph's height
fraction falls relative to `.5` - which shifts with the atlas size. Sweeping `DefaultTtfFont` over its 21 flat-bottomed lowercase glyphs, showing the set ofdistinct `yoffset + texHeight` values:

| atlas | `distanceField = null` | `distanceField = "sdf"` |
|---:|---|---|
| 16 | `[-1, 0]` ❌ | `[-4, -3]` ❌ |
| 24 | `[-1, 0]` ❌ | `[-4, -3]` ❌ |
| **32** | `[-1]` ✅ | `[-4]` ✅ |
| 40 | `[-1, 0]` ❌ | `[-5, -4]` ❌ |
| 48 | `[0, -1]` ❌ | `[-5, -6]` ❌ |
| 64 | `[0, -1]` ❌ | `[-7, -8]` ❌ |
| **72** | `[0]` ✅ | `[-8]` ✅ |
| 96 | `[-1, 0]` ❌ | `[-12, -11]` ❌ |
| **112** | `[-1]` ✅ | `[-14]` ✅ |
| 128 | `[-1, 0]` ❌ | `[-15, -16]` ❌ |
| **144** | `[0]` ✅ | `[-17]` ✅ |
| 160 | `[0, -1]` ❌ | `[-19, -20]` ❌ |
| 192 | `[-1, 0]` ❌ | `[-24, -23]` ❌ |
| **224** | `[0]` ✅ | `[-27]` ✅ |
| **256** | `[-1]` ✅ | `[-32]` ✅ |

A single set means every glyph agrees; two sets mean glyphs sharing a baseline were placed on
different rows.

> [!NOTE]
> **A test pinned to one atlas size can pass even against the unfixed code.** 32, 72, 112, 144, 224 and 256 all agree by luck for this font.

This was deliberately fixed on the `yoffset` side. Rounding `texHeight` instead also works, but it shrinks the glyph bitmap and risks clipping the bottom row of ink.

---

## Defect 2: offsets are measured against the untrimmed bitmap

### Symptom

All text sits above and left of where the font metrics put it, by an amount that **changes with the
atlas size**. Building the same font at a larger atlas for sharper glyphs moves the text.

### Root cause

`renderGlyphToBitmap` renders each glyph with `border` pixels of padding on every edge, and
`LazyBitmapFont.kt:91` then trims that padding off before storing the slice:

```kotlin
val slice = entry.slice.sliceWithBounds(border, border, entry.slice.width - border, entry.slice.height - border)
```

The offsets stored alongside it still come from `g.pos`, which is in the **untrimmed** bitmap's
coordinate space. Every glyph is therefore placed `border` pixels from its own baseline and left edge.

The error is identical for every glyph, so it never shows as misalignment between them. What makes it
matter is that `border` derives from the atlas size:

```kotlin
val border = if (distanceField != null) max(4, (fontSize / 8.0).toIntCeil()) else 1
```

so the rendered offset is `border × (renderSize / atlasSize)` - a 112px atlas drawn at 28px gives
`14 × 0.25 = 3.5px`; a 144px atlas at 36px gives `18 × 0.25 = 4.5px`.

### Evidence

The same text at one size drawn through three atlas sizes must not move. Before the fix the three rows sit at
three different heights relative to a rule drawn at the metrics' baseline; after, they coincide.

Measured at 36px text through a 144px atlas (`border = 18`, scale `0.25`, predicted `4.5px`): text
moved **5px down and 4px right**, and the flat-letter set stayed on a single row.

The sweep table above evidences this defect too, independently of any screenshot. Where the glyphs
*do* agree, the value they agree on should be `0` - a flat-bottomed glyph's ink sits on its baseline.
Instead it is consistently **`−border`**:

| atlas | `border` = `max(4, ceil(atlas/8))` | observed |
|---:|---:|---:|
| 32 | 4 | `−4` |
| 112 | 14 | `−14` |
| 256 | 32 | `−32` |
| 72 | 9 | `−8` |
| 144 | 18 | `−17` |
| 224 | 28 | `−27` |

The first three match `−border` exactly; the last three are one off, which is defect 1 shifting the
value by a pixel on top. With both defects fixed, every one of these becomes `0`.

### Fix

The fix here is to trim the padding from the x and y offsets before drawing the glyph.

---

## Reproduction

1. Load any TTF as a `VectorFont` and take `font.toLazyBitmapFont(atlasSize, distanceField = "sdf")`.
2. Draw a string of flat-bottomed letters - `minimum inflict trim hill fill inn` - through `TextBlock`
   at some `textSize`.
3. Draw a 1px horizontal rule at `font.getFontMetrics(textSize).ascent` below the text box's top, i.e.
   where the font's own metrics put the baseline.
4. **Defect 1** - the letters do not all sit on one row. Use 32px text through a 32px atlas
   (`scale = 1.0`, the `lazyBitmap` default) for the most pronounced case.
5. **Defect 2** - repeat at one text size through several atlas sizes. The text moves relative to the
   rule.

Tested with Inter Regular (OFL) on the JVM backend.

## Screenshots

Rules are drawn where the font's own metrics say the baseline is, so the claim is *"glyphs are not
where the metrics put them"* rather than a calibrated guess. **Section A** uses only flat-bottomed
letters, so any disagreement between them is the renderer's. **Section B** varies only the atlas size.

> [!NOTE]
> Both defects are present in every BEFORE image - section A isolates the jitter, section B the shift.

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/7be826b6-0a55-4919-bffb-f178682047a3) | ![after](https://github.com/user-attachments/assets/83b3b4c0-dbe2-4024-8970-252f652b2fd2) |

**Defect 1** - section A row 1 (32px text / 32px atlas), 4× nearest-neighbour:

| Before | After |
|---|---|
| ![before jitter](https://github.com/user-attachments/assets/e3207fd2-8e3a-4427-a97a-5d49735a5cdd) | ![after jitter](https://github.com/user-attachments/assets/0556c9a4-5a65-4108-9e04-e4d09f2d1243) |

**Defect 2** - section B (28px text through 32/112/224px atlases), 3× nearest-neighbour:

| Before | After |
|---|---|
| ![before shift](https://github.com/user-attachments/assets/5288301b-80e3-46c6-b0ef-70fdd37273c3) | ![after shift](https://github.com/user-attachments/assets/b438df1c-1cc1-457d-8800-8d2278a2631b) |