### PR TITLE
Revert "fix: A couple of text/border alignment issues"

### DIFF
--- a/korlibs-image/src/commonMain/kotlin/korlibs/image/font/LazyBitmapFont.kt
+++ b/korlibs-image/src/commonMain/kotlin/korlibs/image/font/LazyBitmapFont.kt
@@ -105,17 +105,8 @@ class LazyBitmapFont(
                         fontSize, codePoint, slice,
                         //-border,
                         //(border - m.height - m.top + fm.ascent).toIntRound(), xadvance.toIntRound()
-
-                        // The texture here is the slice, where sliceWithBounds() above trims the padding off every edge of the slice.
-                        // However, g.pos is in the untrimmed bitmap's coordinate space so we, must remove the padding again here, else
-                        // every glyph is placed the border width pixels away from where it should be.
-                        // The error is the same for every glyph so doesn't represent as misaligned, but the amount shifted varies
-                        // depending on atlas size
-                        -(g.pos.x - border).toIntRound(),
-                        // The renderer draws the bottom of the glyph at (yoffset + texHeight).
-                        // As texHeight is derived using toIntCeil(), using toIntRound() here causes a disagreement in the glyph's position.
-                        // This is most noticeable with flat-bottomed letters where ceil(h) - round(h) can flip which side of 0 or 1 the .5 of its height lands on
-                        -(g.pos.y - border).toIntCeil(),
+                        -g.pos.x.toIntRound(),
+                        -g.pos.y.toIntRound(),
                         xadvance.toIntRound(),
                     )
                 }

--- a/korlibs-image/src/commonTest/kotlin/korlibs/image/font/LazyBitmapFontTest.kt
+++ b/korlibs-image/src/commonTest/kotlin/korlibs/image/font/LazyBitmapFontTest.kt
@@ -1,83 +1,13 @@
 package korlibs.image.font
 
-import kotlin.math.absoluteValue
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 class LazyBitmapFontTest {
-
-    private val atlasSizes =
-        listOf(16.0, 24.0, 32.0, 40.0, 48.0, 64.0, 72.0, 96.0, 112.0, 128.0, 144.0, 192.0)
-
     @Test
     fun testEnsureSpaceIsEmpty() {
         val glyph = DefaultTtfFontAsBitmap.getOrNull(' '.code)
         val texture = glyph!!.texture
         assertEquals(0, texture.width)
         assertEquals(0, texture.height)
-    }
-
-    /**
-     * A renderer draws a glyph's bottom edge at `yoffset + texHeight`.
-     *
-     * The glyphs tested here report `top == 0` - their outline already sits on the baseline. For those,
-     * that sum is the gap between the baseline and their own ink (i.e. it should be zero). This should
-     * be the same value for all of them, at any atlas size.
-     *
-     * Which glyphs qualify is read from the metrics rather than hardcoded, so this makes no assumption
-     * about the default font's geometry.
-     *
-     * Several [atlasSizes] are scanned because the failure is size-dependent. A glyph's height can land
-     * above or below by a half pixel, so any single size can agree by luck. Sizes 32, 72, 112 and 144
-     * all happen to be lucky for this font and picking one of those would have made this test worthless.
-     */
-    @Test
-    fun `Glyphs that share a baseline with each other should agree on that baseline`() {
-        val distanceFields = listOf(null, "sdf")
-        atlasSizes.forEach { atlasSize ->
-            distanceFields.forEach { distanceField ->
-                val offsets = baselineOffsets(atlasSize, distanceField)
-
-                assertTrue(offsets.isNotEmpty(), "no flat-bottomed glyphs available to test")
-                assertEquals(
-                    expected = 1,
-                    actual = offsets.values.toSet().size,
-                    message = "glyphs sharing one baseline were placed on different rows " +
-                        "(atlasSize=$atlasSize, distanceField=$distanceField): $offsets",
-                )
-            }
-        }
-    }
-
-    /**
-     * Asserts that no borders/padding/etc shift fonts from their baseline.
-     */
-    @Test
-    fun `Glyphs should sit on their baseline regardless of atlasSize`() {
-        val distanceFields = listOf(null, "sdf")
-        atlasSizes.forEach { atlasSize ->
-            distanceFields.forEach { distanceField ->
-                val misplaced = baselineOffsets(atlasSize, distanceField).filterValues { it != 0 }
-
-                assertEquals(
-                    expected = emptyMap(),
-                    actual = misplaced,
-                    message = "glyphs were placed off their own baseline " +
-                        "(atlasSize=$atlasSize, distanceField=$distanceField)",
-                )
-            }
-        }
-    }
-
-    /** Distance from the baseline to the drawn bottom edge, per flat-bottomed glyph. */
-    private fun baselineOffsets(atlasSize: Double, distanceField: String?): Map<Char, Int> {
-        val font = DefaultTtfFont.toLazyBitmapFont(atlasSize, distanceField)
-        return ('a'..'z')
-            .filter { DefaultTtfFont.getGlyphMetrics(atlasSize, it.code).top.absoluteValue < 1e-6 }
-            .associateWith { char ->
-                val glyph = font.getOrNull(char.code)!!
-                glyph.yoffset + glyph.texHeight
-            }
     }
 }


### PR DESCRIPTION
Reverts korlibs/korlibs#211

It looks we have a unit test failure with this changes in the Korge repo:
```
ViewsJvmTest[jvm] > testTextBounds[jvm] FAILED
    java.lang.AssertionError at Assert.java:89
        Caused by: java.lang.AssertionError at ViewsJvmTest.kt:56
```