### PR TITLE
bugfix: Remove proxy in karma extra config

### DIFF
--- a/korlibs-audio/karma.config.d/extra.karma.config.js
+++ b/korlibs-audio/karma.config.d/extra.karma.config.js
@@ -1,3 +1,6 @@
+const fs = require('fs');
+const path = require('path');
+
 const basePath = config.basePath.replace(/\/node_modules$/, "");
 
 config.set({
@@ -6,12 +9,30 @@ config.set({
         ...config.files,
         { pattern: 'kotlin/**/*', included: false, served: true, watched: false }
     ],
-    proxies: {
-        '/': '/base/kotlin/'
-    },
+    middleware: [...(config.middleware || []), 'kotlinResources'],
+    plugins: [
+        ...(config.plugins || []),
+        {
+            'middleware:kotlinResources': ['factory', function () {
+                return function (request, response, next) {
+                    const urlPath = decodeURIComponent(request.url.split('?')[0]);
+                    const relative = urlPath.replace(/^\//, ''); // strip only the leading slash
+                    // real resources live under <basePath>/kotlin/..., matching
+                    // what '/' -> '/base/kotlin/' proxy used to resolve to (but without recursion issue)
+                    const filePath = path.join(basePath, 'kotlin', relative);
+
+                    fs.readFile(filePath, (err, data) => {
+                        if (err) return next();
+                        response.writeHead(200);
+                        response.end(data);
+                    });
+                };
+            }]
+        }
+    ],
     client: {
         mocha: {
-            timeout: 20000  // adjust as needed
+            timeout: 20000
         }
     }
 });

--- a/korlibs-image/karma.config.d/extra.karma.config.js
+++ b/korlibs-image/karma.config.d/extra.karma.config.js
@@ -1,3 +1,6 @@
+const fs = require('fs');
+const path = require('path');
+
 const basePath = config.basePath.replace(/\/node_modules$/, "");
 
 config.set({
@@ -6,12 +9,30 @@ config.set({
         ...config.files,
         { pattern: 'kotlin/**/*', included: false, served: true, watched: false }
     ],
-    proxies: {
-        '/': '/base/kotlin/'
-    },
+    middleware: [...(config.middleware || []), 'kotlinResources'],
+    plugins: [
+        ...(config.plugins || []),
+        {
+            'middleware:kotlinResources': ['factory', function () {
+                return function (request, response, next) {
+                    const urlPath = decodeURIComponent(request.url.split('?')[0]);
+                    const relative = urlPath.replace(/^\//, ''); // strip only the leading slash
+                    // real resources live under <basePath>/kotlin/..., matching
+                    // what '/' -> '/base/kotlin/' proxy used to resolve to (but without recursion issue)
+                    const filePath = path.join(basePath, 'kotlin', relative);
+
+                    fs.readFile(filePath, (err, data) => {
+                        if (err) return next();
+                        response.writeHead(200);
+                        response.end(data);
+                    });
+                };
+            }]
+        }
+    ],
     client: {
         mocha: {
-            timeout: 20000  // adjust as needed
+            timeout: 20000
         }
     }
 });

--- a/korlibs-io/karma.config.d/extra.karma.config.js
+++ b/korlibs-io/karma.config.d/extra.karma.config.js
@@ -1,3 +1,6 @@
+const fs = require('fs');
+const path = require('path');
+
 const basePath = config.basePath.replace(/\/node_modules$/, "");
 
 config.set({
@@ -6,12 +9,30 @@ config.set({
         ...config.files,
         { pattern: 'kotlin/**/*', included: false, served: true, watched: false }
     ],
-    proxies: {
-        '/': '/base/kotlin/'
-    },
+    middleware: [...(config.middleware || []), 'kotlinResources'],
+    plugins: [
+        ...(config.plugins || []),
+        {
+            'middleware:kotlinResources': ['factory', function () {
+                return function (request, response, next) {
+                    const urlPath = decodeURIComponent(request.url.split('?')[0]);
+                    const relative = urlPath.replace(/^\//, ''); // strip only the leading slash
+                    // real resources live under <basePath>/kotlin/..., matching
+                    // what '/' -> '/base/kotlin/' proxy used to resolve to (but without recursion issue)
+                    const filePath = path.join(basePath, 'kotlin', relative);
+
+                    fs.readFile(filePath, (err, data) => {
+                        if (err) return next();
+                        response.writeHead(200);
+                        response.end(data);
+                    });
+                };
+            }]
+        }
+    ],
     client: {
         mocha: {
-            timeout: 20000  // adjust as needed
+            timeout: 20000
         }
     }
 });

--- a/korlibs-wasm/karma.config.d/extra.karma.config.js
+++ b/korlibs-wasm/karma.config.d/extra.karma.config.js
@@ -1,3 +1,6 @@
+const fs = require('fs');
+const path = require('path');
+
 const basePath = config.basePath.replace(/\/node_modules$/, "");
 
 config.set({
@@ -6,12 +9,30 @@ config.set({
         ...config.files,
         { pattern: 'kotlin/**/*', included: false, served: true, watched: false }
     ],
-    proxies: {
-        '/': '/base/kotlin/'
-    },
+    middleware: [...(config.middleware || []), 'kotlinResources'],
+    plugins: [
+        ...(config.plugins || []),
+        {
+            'middleware:kotlinResources': ['factory', function () {
+                return function (request, response, next) {
+                    const urlPath = decodeURIComponent(request.url.split('?')[0]);
+                    const relative = urlPath.replace(/^\//, ''); // strip only the leading slash
+                    // real resources live under <basePath>/kotlin/..., matching
+                    // what '/' -> '/base/kotlin/' proxy used to resolve to (but without recursion issue)
+                    const filePath = path.join(basePath, 'kotlin', relative);
+
+                    fs.readFile(filePath, (err, data) => {
+                        if (err) return next();
+                        response.writeHead(200);
+                        response.end(data);
+                    });
+                };
+            }]
+        }
+    ],
     client: {
         mocha: {
-            timeout: 20000  // adjust as needed
+            timeout: 20000
         }
     }
 });


### PR DESCRIPTION
## Description

The current `extra.karma.config.js` files use a proxy to redirect files from `/` to `/base/kotlin` for files that do not resolve under the root path. That is needed to find tests and assets. However, this redirect will lead to recursion for files that do not resolve, like `$catalog.json`. You will notice this issue when running browser tests for the audio module and the logs show a recursive path of `/base/kotlin/base/kotlin/base/kotlin/.../$catalog.json` not being resolved.

## Solution

It is possible to avoid the usage of a proxy and instead use a (more complex) middleware logic that does not redirect on `/`.
This way the `/$catalog.json` resolves instantly to 404 not found error and stops there. The file itself is of no interest, so the resolution is acceptable. For any other files, we also try the base path.